### PR TITLE
Site name override

### DIFF
--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { Nav, Navbar, NavItem } from 'react-bootstrap';
 
+const siteName = process.env.SITE_NAME || 'Gambit Local';
+
 const Header = () => (
   <Navbar>
     <Navbar.Header>
       <Navbar.Brand>
-        <a href="/">Gambit</a>
+        <a href="/">{ siteName }</a>
       </Navbar.Brand>
     </Navbar.Header>
     <Nav>


### PR DESCRIPTION
We're planning to use Aurora instead of a separate Gambit Admin web app, so it seems overkill to create different environments while we're in pre-production

In the meantime -- let's add a config variable to avoid hardcoding the site name in the navbar.