### PR TITLE
Gambit Request view

### DIFF
--- a/src/Components/ConversationDetail.js
+++ b/src/Components/ConversationDetail.js
@@ -52,7 +52,6 @@ export default class ConversationDetail extends React.Component {
             </Col>
           </FormGroup>
         </Form>
-        <h2>Messages</h2>
         <MessageList conversationId={this.conversationId} />
       </Grid>
     );

--- a/src/Components/ConversationList.js
+++ b/src/Components/ConversationList.js
@@ -35,7 +35,7 @@ export default class ConversationList extends React.Component {
               return <RequestError error={error} />
             } else {
               return (
-                <Table striped bordered hover>
+                <Table striped hover>
                   <tbody>
                   <tr>
                     <th>Last Updated</th>

--- a/src/Components/ConversationList.js
+++ b/src/Components/ConversationList.js
@@ -39,8 +39,6 @@ export default class ConversationList extends React.Component {
                   <tbody>
                   <tr>
                     <th>Last Updated</th>
-                    <th>ID</th>
-                    <th>Platform</th>
                     <th>Platform User ID</th>
                     <th>Current Campaign</th>
                     <th>Topic</th>
@@ -61,10 +59,6 @@ export default class ConversationList extends React.Component {
       <tr key={ conversation._id }>
         <td>
           <small><Moment format={ config.dateFormat }>{ conversation.updatedAt }</Moment></small>
-        </td>
-        <td><Link to={`conversations/${conversation._id}`}>{ conversation._id }</Link></td>
-        <td>
-          <small>{ conversation.platform }</small>
         </td>
         <td><Link to={`conversations/${conversation._id}`}>{ conversation.platformUserId }</Link></td>
         <td>{ conversation.campaignId }</td>

--- a/src/Components/GambitRequest.js
+++ b/src/Components/GambitRequest.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Col, ControlLabel, Form, FormControl, FormGroup, Grid } from 'react-bootstrap';
+import MessageList from './MessageList';
+
+export default class GambitRequest extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.requestId = this.props.match.params.requestId;
+  }
+
+  render() {
+    return (
+      <Grid fluid={true}>
+        <Form horizontal>
+          <FormGroup>
+            <Col sm={2}>
+              <ControlLabel>Request Id</ControlLabel>
+            </Col>
+            <Col sm={10}>
+              <FormControl.Static>{ this.requestId }</FormControl.Static>
+            </Col>
+          </FormGroup>
+        </Form>
+        <MessageList requestId={this.requestId} />
+      </Grid>
+    );
+  }
+}

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -6,7 +6,6 @@ export default class Home extends React.Component {
   render() {
     return (
       <Grid fluid={true}>
-        <PageHeader>Latest reply messages</PageHeader>
         <MessageList />
       </Grid>
     );

--- a/src/Components/Main.js
+++ b/src/Components/Main.js
@@ -4,6 +4,7 @@ import { Switch, Route, } from 'react-router-dom';
 import Home from './Home';
 import ConversationList from './ConversationList';
 import ConversationDetail from './ConversationDetail';
+import GambitRequest from './GambitRequest';
 
 // The Roster component matches one of two different routes
 // depending on the full pathname
@@ -14,11 +15,19 @@ const Conversations = () => (
   </Switch>
 )
 
+const Requests = () => (
+  <Switch>
+    <Route exact path='/requests' component={Home}/>
+    <Route path='/requests/:requestId' component={GambitRequest}/>
+  </Switch>
+)
+
 const Main = () => (
   <main>
     <Switch>
       <Route exact path='/' component={Home}/>
       <Route path='/conversations' component={Conversations}/>
+      <Route path='/requests' component={Requests}/>
     </Switch>
   </main>
 );

--- a/src/Components/MessageList.js
+++ b/src/Components/MessageList.js
@@ -13,7 +13,7 @@ export default class MessageList extends React.Component {
   constructor(props) {
     super(props);
 
-    this.requestUrl = gambit.conversationsUrl('messages?sort=-createdAt');
+    this.requestUrl = gambit.conversationsUrl('messages?sort=-createdAt&limit=50');
     if (this.props.conversationId) {
        const query = encodeURIComponent(`"conversationId":"${this.props.conversationId}"`);
        this.requestUrl = `${this.requestUrl}&query={${query}}`;

--- a/src/Components/MessageList.js
+++ b/src/Components/MessageList.js
@@ -13,7 +13,7 @@ export default class MessageList extends React.Component {
   constructor(props) {
     super(props);
 
-    this.requestUrl = gambit.conversationsUrl('messages?sort=-createdAt&limit=50');
+    this.requestUrl = gambit.conversationsUrl('messages?sort=-createdAt&limit=50&populate=conversationId');
     if (this.props.conversationId) {
        const query = encodeURIComponent(`"conversationId":"${this.props.conversationId}"`);
        this.requestUrl = `${this.requestUrl}&query={${query}}`;
@@ -53,7 +53,7 @@ export default class MessageList extends React.Component {
   renderHeader() {
     let userCell;
     if (! this.props.conversationId) {
-      userCell = <th>Conversation</th>;
+      userCell = <th>Platform User ID</th>;
     }
 
     return (
@@ -125,8 +125,8 @@ export default class MessageList extends React.Component {
   renderMessageRow(message) {
     let userCell;
     if (! this.props.conversationId) {
-      const uri = `/conversations/${message.conversationId}`;
-      userCell = <td><small><Link to={uri}>{ message.conversationId }</Link></small></td>;
+      const uri = `/conversations/${message.conversationId._id}`;
+      userCell = <td><small><Link to={uri}>{ message.conversationId.platformUserId }</Link></small></td>;
     }
 
 

--- a/src/Components/MessageList.js
+++ b/src/Components/MessageList.js
@@ -1,19 +1,23 @@
 import React from 'react';
 import Request from 'react-http-request';
 import {Link} from 'react-router-dom';
-import {Table, ListGroup, ListGroupItem, Image} from 'react-bootstrap';
+import {Table, ListGroup, ListGroupItem, Image, Pager} from 'react-bootstrap';
 import Moment from 'react-moment';
 import RequestError from './RequestError';
 import RequestLoading from './RequestLoading';
 
+const queryString = require('query-string');
 const config = require('../config');
 const gambit = require('../gambit');
+
+const pageSize = config.resultsPageSize; 
 
 export default class MessageList extends React.Component {
   constructor(props) {
     super(props);
 
-    this.requestUrl = gambit.conversationsUrl('messages?sort=-createdAt&limit=50&populate=conversationId');
+    const path = `messages?sort=-createdAt&limit=${pageSize}&populate=conversationId`;
+    this.requestUrl = gambit.conversationsUrl(path);
     if (this.props.conversationId) {
        const query = encodeURIComponent(`"conversationId":"${this.props.conversationId}"`);
        this.requestUrl = `${this.requestUrl}&query={${query}}`;
@@ -21,6 +25,48 @@ export default class MessageList extends React.Component {
       const query = encodeURIComponent(`"metadata.requestId":"${this.props.requestId}"`);
       this.requestUrl = `${this.requestUrl}&query={${query}}`;
     }
+
+    const query = queryString.parse(window.location.search);
+    this.skipCount = Number(query.skip);
+    if (this.skipCount) {
+      this.requestUrl =`${this.requestUrl}&skip=${this.skipCount}`;
+    } else {
+      this.skipCount = 0;
+    }
+  }
+
+  renderTablePager(result) {
+    const totalResultCount = result.header['x-gambit-results-count'];
+    const pageCount = result.body.length;
+    const startNumber = this.skipCount + 1;
+    const endNumber = startNumber + pageCount - 1;
+
+    const location = window.location;
+    const url = [location.protocol, '//', location.host, location.pathname].join('');
+
+    let leftPagerItem;
+    if (this.skipCount) {
+      const prevSkip = this.skipCount - pageSize;
+      let prevUrl = url;
+      if (prevSkip > 0) {
+        prevUrl = `${url}?skip=${prevSkip}`;
+      }
+      leftPagerItem = <Pager.Item previous href={ prevUrl }>Previous</Pager.Item>;
+    }
+
+    let rightPagerItem;
+    if (totalResultCount > pageSize && endNumber < totalResultCount) {
+      const nextUrl = `${url}?skip=${this.skipCount + pageSize}`;
+      rightPagerItem = <Pager.Item next href={ nextUrl }>Next</Pager.Item>;
+    }
+
+    return (
+      <Pager>
+        {leftPagerItem}
+        <small>Displaying { startNumber }-{ endNumber } of { totalResultCount } messages</small>
+        {rightPagerItem}
+      </Pager>
+    );
   }
 
   render() {
@@ -38,13 +84,18 @@ export default class MessageList extends React.Component {
             } else if (error) {
               return <RequestError error={error} />
             } else {
+              const header = this.renderTablePager(result);
               return (
-                <Table striped bordered>
+                <div>
+                { header }
+                <Table striped>
                   <tbody>
                     { this.renderHeader() }
                     { result.body.map(message => this.renderMessageRow(message)) }
                   </tbody>
                 </Table>
+                { header }
+                </div>
               );
             }
           }
@@ -54,11 +105,15 @@ export default class MessageList extends React.Component {
   }
 
   renderDate(message) {
-    const uri = `/requests/${message.metadata.requestId}`;
     const dateFormat = config.dateFormat;
+    const createdAt = <Moment format={dateFormat}>{ message.createdAt }</Moment>;
+    if (!message.metadata) {
+      return createdAt;
+    }
+    const uri = `/requests/${message.metadata.requestId}`;
     return (
       <Link to={uri}>
-        <Moment format={dateFormat}>{ message.createdAt }</Moment>
+        { createdAt }
       </Link>
     );
   }
@@ -66,7 +121,7 @@ export default class MessageList extends React.Component {
   renderHeader() {
     let userCell;
     if (! this.props.conversationId) {
-      userCell = <th>Platform User ID</th>;
+      userCell = <th>User</th>;
     }
 
     return (
@@ -77,7 +132,6 @@ export default class MessageList extends React.Component {
         <th>Message</th>
         <th>Topic</th>
         <th>Campaign</th>
-        <th>Template</th>
       </tr>
     );
   }
@@ -124,8 +178,16 @@ export default class MessageList extends React.Component {
         </ListGroupItem>
       );
     }
+    let templateGroupItem;
+    if (message.template) {
+      templateGroupItem = (
+        <ListGroupItem>
+          <small>Template: { message.template }</small>
+        </ListGroupItem>
+      );
+    }
     let retryGroupItem;
-    if (message.metadata.retryCount) {
+    if (message.metadata && message.metadata.retryCount) {
       retryGroupItem = (
         <ListGroupItem>
           <small>Retry Count: { message.metadata.retryCount }</small>
@@ -139,6 +201,7 @@ export default class MessageList extends React.Component {
         { broadcastGroupItem }
         { agentGroupItem }
         { matchGroupItem }
+        { templateGroupItem }
         { retryGroupItem }
       </ListGroup>
     );
@@ -165,9 +228,6 @@ export default class MessageList extends React.Component {
           <small>{ message.topic }</small>
         </td>
         <td>{ message.campaignId }</td>
-        <td>
-          <small>{ message.template }</small>
-        </td>
       </tr>
     );
   }

--- a/src/Components/MessageList.js
+++ b/src/Components/MessageList.js
@@ -17,6 +17,9 @@ export default class MessageList extends React.Component {
     if (this.props.conversationId) {
        const query = encodeURIComponent(`"conversationId":"${this.props.conversationId}"`);
        this.requestUrl = `${this.requestUrl}&query={${query}}`;
+    } else if (this.props.requestId) {
+      const query = encodeURIComponent(`"metadata.requestId":"${this.props.requestId}"`);
+      this.requestUrl = `${this.requestUrl}&query={${query}}`;
     }
   }
 
@@ -47,6 +50,16 @@ export default class MessageList extends React.Component {
           }
         }
       </Request>
+    );
+  }
+
+  renderDate(message) {
+    const uri = `/requests/${message.metadata.requestId}`;
+    const dateFormat = config.dateFormat;
+    return (
+      <Link to={uri}>
+        <Moment format={dateFormat}>{ message.createdAt }</Moment>
+      </Link>
     );
   }
 
@@ -111,6 +124,14 @@ export default class MessageList extends React.Component {
         </ListGroupItem>
       );
     }
+    let retryGroupItem;
+    if (message.metadata.retryCount) {
+      retryGroupItem = (
+        <ListGroupItem>
+          <small>Retry Count: { message.metadata.retryCount }</small>
+        </ListGroupItem>
+      );
+    }
     return (
       <ListGroup>
         { attachmentGroupItem }
@@ -118,6 +139,7 @@ export default class MessageList extends React.Component {
         { broadcastGroupItem }
         { agentGroupItem }
         { matchGroupItem }
+        { retryGroupItem }
       </ListGroup>
     );
   }
@@ -129,19 +151,10 @@ export default class MessageList extends React.Component {
       userCell = <td><small><Link to={uri}>{ message.conversationId.platformUserId }</Link></small></td>;
     }
 
-
-    const dateFormat = config.dateFormat;
-    let createdAtCell;
-    if (message.createdAt) {
-      createdAtCell = <Moment format={dateFormat}>{ message.createdAt }</Moment>
-    }else if(message.date){
-      createdAtCell = <Moment format={dateFormat}>{ message.date }</Moment>
-    }
-
     return (
       <tr key={ message._id }>
         <td className='date'>
-          <small>{ createdAtCell }</small>
+          <small>{ this.renderDate(message) }</small>
         </td>
         { userCell }
         <td>

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,7 @@ const configVars = {
   conversationsBaseUri: process.env.REACT_APP_DS_GAMBIT_CONVERSATIONS_API_BASEURI || 'http://localhost:5100/api/v1/',
   siteName: process.env.REACT_APP_SITE_NAME  || 'Gambit Local',
   dateFormat: 'MM/DD/YY, h:mm:ss a',
+  resultsPageSize: 50,
 };
 
 module.exports = configVars;


### PR DESCRIPTION
* Adds a `GambitRequest` component to view MessageList by request ID:`/requests/:requestId` 
* Adds a `limit` filter to hotfix https://github.com/DoSomething/gambit-conversations/issues/163 and get Gambit Admin Staging running again
* Populates `conversationId` to display Platform User ID instead of Conversation ID
* Displays `retryCount` when exists
