### PR TITLE
Campaign List, Detail

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -25,6 +25,9 @@
   width: 150px;
   height: 150px;
 }
+td {
+  white-space: pre-line;
+}
 
 @keyframes App-logo-spin {
   from { transform: rotate(0deg); }

--- a/src/Components/CampaignDetail.js
+++ b/src/Components/CampaignDetail.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Request from 'react-http-request';
-import { Col, ControlLabel, Form, FormControl, FormGroup, Grid, Nav, NavItem, PageHeader, Panel, Table } from 'react-bootstrap';
+import { Col, ControlLabel, Form, FormControl, FormGroup, Grid, PageHeader, Panel, Tab, Tabs, Table, Well } from 'react-bootstrap';
 import Moment from 'react-moment';
 import RequestError from './RequestError';
 import RequestLoading from './RequestLoading';
@@ -20,21 +20,23 @@ export default class CampaignDetail extends React.Component {
   render() {
     return (
       <Grid fluid={true}>
-        { this.renderCampaign() }
+        { this.fetchCampaign() }
       </Grid>
     );
   }
 
-  renderNav() {
+  renderNav(campaign) {
     return (
-      <Nav bsStyle="tabs" activeKey={1}>
-        <NavItem eventKey={1} href="/home">Details</NavItem>
-        <NavItem eventKey={2} title="Item">Messages</NavItem>
-      </Nav>
+      <Tabs defaultActiveKey={0} animation={false} id="noanim-tab-example">
+        <Tab eventKey={0} title="Details"><br />
+          { this.renderDetails(campaign) }
+        </Tab>
+        <Tab eventKey={1} title="Messages"><br />test</Tab>
+      </Tabs>
     );
   }
 
-  renderCampaign() {
+  fetchCampaign() {
     return (
       <Request
         url={ this.requestUrl }
@@ -53,11 +55,7 @@ export default class CampaignDetail extends React.Component {
               return (
                 <div>                                  
                   <PageHeader>{campaign.title}</PageHeader>
-                  { this.renderNav() }
-                  <br />
-                  { this.renderDetails(campaign) }
-                  <h2>Templates</h2>
-                  { this.renderTemplates(campaign.templates) }
+                  { this.renderNav(campaign) }
                 </div>
               );
             }
@@ -69,34 +67,38 @@ export default class CampaignDetail extends React.Component {
 
   renderDetails(campaign) {
     return (
-      <Form horizontal>
-        <FormGroup>
-          <Col sm={2}>
-            <ControlLabel>Keywords</ControlLabel>
-          </Col>
-          <Col sm={10}>
-            <FormControl.Static>{ campaign.keywords.join(',') }</FormControl.Static>
-          </Col>
-        </FormGroup>
-        <FormGroup>
-          <Col sm={2}>
-            <ControlLabel>Status</ControlLabel>
-          </Col>
-          <Col sm={10}>
-            <FormControl.Static>{ campaign.status }</FormControl.Static>
-          </Col>
-        </FormGroup>
-        <FormGroup>
-          <Col sm={2}>
-            <ControlLabel>Cached At</ControlLabel>
-          </Col>
-          <Col sm={10}>
-            <FormControl.Static>
-              <Moment format={config.dateFormat}>{ campaign.updatedAt }
-              </Moment></FormControl.Static>
-          </Col>
-        </FormGroup>
-      </Form>
+    <div>
+        <Form horizontal>
+          <FormGroup>
+            <Col sm={2}>
+              <ControlLabel>Keywords</ControlLabel>
+            </Col>
+            <Col sm={10}>
+              <FormControl.Static>{ campaign.keywords.join(',') }</FormControl.Static>
+            </Col>
+          </FormGroup>
+          <FormGroup>
+            <Col sm={2}>
+              <ControlLabel>Status</ControlLabel>
+            </Col>
+            <Col sm={10}>
+              <FormControl.Static>{ campaign.status }</FormControl.Static>
+            </Col>
+          </FormGroup>
+          <FormGroup>
+            <Col sm={2}>
+              <ControlLabel>Cached At</ControlLabel>
+            </Col>
+            <Col sm={10}>
+              <FormControl.Static>
+                <Moment format={config.dateFormat}>{ campaign.updatedAt }
+                </Moment></FormControl.Static>
+            </Col>
+          </FormGroup>
+        </Form>
+        <h2>Templates</h2>
+        { this.renderTemplates(campaign.templates) }
+      </div>
     );
   }
 
@@ -111,15 +113,5 @@ export default class CampaignDetail extends React.Component {
       );
     });
     return <Table striped><tbody>{ rows }</tbody></Table>;
-  }
-
-  renderSummary(campaign) {
-    return (
-      <tr key={ campaign._id }>
-        <td>{ campaign._id }</td>
-        <td>{ campaign.title }</td>
-        <td>{ campaign.keywords.join(',') }</td>
-      </tr>
-    );
   }
 }

--- a/src/Components/CampaignDetail.js
+++ b/src/Components/CampaignDetail.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Request from 'react-http-request';
-import { Col, ControlLabel, Form, FormControl, FormGroup, Grid, PageHeader, Table } from 'react-bootstrap';
+import { Col, ControlLabel, Form, FormControl, FormGroup, Grid, Nav, NavItem, PageHeader, Panel, Table } from 'react-bootstrap';
 import Moment from 'react-moment';
 import RequestError from './RequestError';
 import RequestLoading from './RequestLoading';
@@ -25,6 +25,15 @@ export default class CampaignDetail extends React.Component {
     );
   }
 
+  renderNav() {
+    return (
+      <Nav bsStyle="tabs" activeKey={1}>
+        <NavItem eventKey={1} href="/home">Details</NavItem>
+        <NavItem eventKey={2} title="Item">Messages</NavItem>
+      </Nav>
+    );
+  }
+
   renderCampaign() {
     return (
       <Request
@@ -42,10 +51,12 @@ export default class CampaignDetail extends React.Component {
             } else {
               const campaign = result.body;
               return (
-                <div>
+                <div>                                  
                   <PageHeader>{campaign.title}</PageHeader>
+                  { this.renderNav() }
+                  <br />
                   { this.renderDetails(campaign) }
-                  <h3>Templates</h3>
+                  <h2>Templates</h2>
                   { this.renderTemplates(campaign.templates) }
                 </div>
               );

--- a/src/Components/CampaignDetail.js
+++ b/src/Components/CampaignDetail.js
@@ -29,7 +29,7 @@ export default class CampaignDetail extends React.Component {
   renderNav(campaign) {
     return (
       <Tabs defaultActiveKey={0} animation={false} id="campaign-tabs">
-        <Tab eventKey={0} title="Messages"><br /><MessageList /></Tab>
+        <Tab eventKey={0} title="Messages"><br /><MessageList campaignId={this.campaignId} /></Tab>
         <Tab eventKey={1} title="Details"><br />
           { this.renderDetails(campaign) }
         </Tab>   

--- a/src/Components/CampaignDetail.js
+++ b/src/Components/CampaignDetail.js
@@ -1,0 +1,114 @@
+import React from 'react';
+import Request from 'react-http-request';
+import { Col, ControlLabel, Form, FormControl, FormGroup, Grid, PageHeader, Table } from 'react-bootstrap';
+import Moment from 'react-moment';
+import RequestError from './RequestError';
+import RequestLoading from './RequestLoading';
+
+const config = require('../config');
+const gambit = require('../gambit');
+
+export default class CampaignDetail extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.campaignId = this.props.match.params.campaignId;
+    this.requestUrl = gambit.conversationsUrl(`campaigns/${this.campaignId}`);
+    console.log(this.requestUrl);
+  }
+
+  render() {
+    return (
+      <Grid fluid={true}>
+        { this.renderCampaign() }
+      </Grid>
+    );
+  }
+
+  renderCampaign() {
+    return (
+      <Request
+        url={ this.requestUrl }
+        method='get'
+        accept='application/json'
+        verbose={true}
+      >
+        {
+          ({error, result, loading}) => {
+            if (loading) {
+              return <RequestLoading />;
+            } else if (error) {
+              return <RequestError error={error} />
+            } else {
+              const campaign = result.body;
+              return (
+                <div>
+                  <PageHeader>{campaign.title}</PageHeader>
+                  { this.renderDetails(campaign) }
+                  <h3>Templates</h3>
+                  { this.renderTemplates(campaign.templates) }
+                </div>
+              );
+            }
+          }
+        }
+      </Request>
+    );
+  }
+
+  renderDetails(campaign) {
+    return (
+      <Form horizontal>
+        <FormGroup>
+          <Col sm={2}>
+            <ControlLabel>Keywords</ControlLabel>
+          </Col>
+          <Col sm={10}>
+            <FormControl.Static>{ campaign.keywords.join(',') }</FormControl.Static>
+          </Col>
+        </FormGroup>
+        <FormGroup>
+          <Col sm={2}>
+            <ControlLabel>Status</ControlLabel>
+          </Col>
+          <Col sm={10}>
+            <FormControl.Static>{ campaign.status }</FormControl.Static>
+          </Col>
+        </FormGroup>
+        <FormGroup>
+          <Col sm={2}>
+            <ControlLabel>Cached At</ControlLabel>
+          </Col>
+          <Col sm={10}>
+            <FormControl.Static>
+              <Moment format={config.dateFormat}>{ campaign.updatedAt }
+              </Moment></FormControl.Static>
+          </Col>
+        </FormGroup>
+      </Form>
+    );
+  }
+
+  renderTemplates(templates) {
+    const templateNames = Object.keys(templates).sort();
+    const rows = templateNames.map((template) => {
+      return (
+        <tr>
+          <td sm={3}><strong>{ template }</strong></td>
+          <td sm={9}>{ templates[template] }</td>
+        </tr>
+      );
+    });
+    return <Table striped><tbody>{ rows }</tbody></Table>;
+  }
+
+  renderSummary(campaign) {
+    return (
+      <tr key={ campaign._id }>
+        <td>{ campaign._id }</td>
+        <td>{ campaign.title }</td>
+        <td>{ campaign.keywords.join(',') }</td>
+      </tr>
+    );
+  }
+}

--- a/src/Components/CampaignDetail.js
+++ b/src/Components/CampaignDetail.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Request from 'react-http-request';
 import { Col, ControlLabel, Form, FormControl, FormGroup, Grid, PageHeader, Panel, Tab, Tabs, Table, Well } from 'react-bootstrap';
 import Moment from 'react-moment';
+import MessageList from './MessageList';
 import RequestError from './RequestError';
 import RequestLoading from './RequestLoading';
 
@@ -27,11 +28,11 @@ export default class CampaignDetail extends React.Component {
 
   renderNav(campaign) {
     return (
-      <Tabs defaultActiveKey={0} animation={false} id="noanim-tab-example">
-        <Tab eventKey={0} title="Details"><br />
+      <Tabs defaultActiveKey={0} animation={false} id="campaign-tabs">
+        <Tab eventKey={0} title="Messages"><br /><MessageList /></Tab>
+        <Tab eventKey={1} title="Details"><br />
           { this.renderDetails(campaign) }
-        </Tab>
-        <Tab eventKey={1} title="Messages"><br />test</Tab>
+        </Tab>   
       </Tabs>
     );
   }
@@ -54,7 +55,7 @@ export default class CampaignDetail extends React.Component {
               const campaign = result.body;
               return (
                 <div>                                  
-                  <PageHeader>{campaign.title}</PageHeader>
+                  <PageHeader>{campaign.title} <small></small></PageHeader>
                   { this.renderNav(campaign) }
                 </div>
               );

--- a/src/Components/CampaignList.js
+++ b/src/Components/CampaignList.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import Request from 'react-http-request';
+import {Link} from 'react-router-dom';
+import { Grid, PageHeader, Table } from 'react-bootstrap';
+import RequestError from './RequestError';
+import RequestLoading from './RequestLoading';
+
+const gambit = require('../gambit');
+
+export default class CampaignList extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.requestUrl = gambit.conversationsUrl(`campaigns?sort=title&query={"status":"active"}`);
+  }
+
+  render() {
+    return (
+      <Grid fluid={true}>
+        <PageHeader>Campaigns</PageHeader>
+        { this.renderList() }
+      </Grid>
+    );
+  }
+
+  renderList() {
+    return (
+      <Request
+        url={ this.requestUrl }
+        method='get'
+        accept='application/json'
+        verbose={true}
+      >
+        {
+          ({error, result, loading}) => {
+            if (loading) {
+              return <RequestLoading />;
+            } else if (error) {
+              return <RequestError error={error} />
+            } else {
+              return (
+                <Table striped hover>
+                  <tbody>
+                  <tr>
+                    <th>ID</th>
+                    <th>Title</th>
+                    <th>Keywords</th>
+                  </tr>
+                  { result.body.map(campaign => this.renderSummary(campaign)) }
+                  </tbody>
+                </Table>
+              );
+            }
+          }
+        }
+      </Request>
+    );
+  }
+
+  renderSummary(campaign) {
+    const campaignId = campaign._id;
+
+    return (
+      <tr key={ campaignId }>
+        <td>{ campaignId }</td>
+        <td><Link to={ `campaigns/${campaignId}` }>{ campaign.title }</Link></td>
+        <td>{ campaign.keywords.join(',') }</td>
+      </tr>
+    );
+  }
+}

--- a/src/Components/CampaignList.js
+++ b/src/Components/CampaignList.js
@@ -63,8 +63,12 @@ export default class CampaignList extends React.Component {
     return (
       <tr key={ campaignId }>
         <td>{ campaignId }</td>
-        <td><Link to={ `campaigns/${campaignId}` }>{ campaign.title }</Link></td>
-        <td>{ campaign.keywords.join(',') }</td>
+        <td>
+          <Link to={ `campaigns/${campaignId}` }>
+            <strong>{ campaign.title }</strong>
+          </Link>
+        </td>
+        <td>{ campaign.keywords.join(', ') }</td>
       </tr>
     );
   }

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -49,7 +49,7 @@ export default class Header extends React.Component {
           </Navbar.Brand>
         </Navbar.Header>
         <Nav>
-          <NavItem eventKey={1} href="/conversations">Conversations</NavItem>
+          <NavItem eventKey={1} href="/campaigns">Campaigns</NavItem>
         </Nav>
         <Navbar.Form pullRight>
           <SearchForm />

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Grid } from 'react-bootstrap';
-import MessageList from './MessageList';
+import CampaignList from './CampaignList';
 
 export default class Home extends React.Component {
   render() {
     return (
       <Grid fluid={true}>
-        <MessageList />
+        <CampaignList />
       </Grid>
     );
   }

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Grid } from 'react-bootstrap';
-import CampaignList from './CampaignList';
+import MessageList from './MessageList';
 
 export default class Home extends React.Component {
   render() {
     return (
       <Grid fluid={true}>
-        <CampaignList />
+        <MessageList />
       </Grid>
     );
   }

--- a/src/Components/Main.js
+++ b/src/Components/Main.js
@@ -2,12 +2,19 @@ import React from 'react';
 import { Switch, Route, } from 'react-router-dom';
 
 import Home from './Home';
+import CampaignList from './CampaignList';
+import CampaignDetail from './CampaignDetail';
 import ConversationList from './ConversationList';
 import ConversationDetail from './ConversationDetail';
 import GambitRequest from './GambitRequest';
 
-// The Roster component matches one of two different routes
-// depending on the full pathname
+const Campaigns = () => (
+  <Switch>
+    <Route exact path='/campaigns' component={CampaignList}/>
+    <Route path='/campaigns/:campaignId' component={CampaignDetail}/>
+  </Switch>
+)
+
 const Conversations = () => (
   <Switch>
     <Route exact path='/conversations' component={ConversationList}/>
@@ -26,6 +33,7 @@ const Main = () => (
   <main>
     <Switch>
       <Route exact path='/' component={Home}/>
+      <Route path='/campaigns' component={Campaigns}/>
       <Route path='/conversations' component={Conversations}/>
       <Route path='/requests' component={Requests}/>
     </Switch>

--- a/src/Components/MessageList.js
+++ b/src/Components/MessageList.js
@@ -18,7 +18,11 @@ export default class MessageList extends React.Component {
 
     const path = `messages?sort=-createdAt&limit=${pageSize}&populate=conversationId`;
     this.requestUrl = gambit.conversationsUrl(path);
-    if (this.props.conversationId) {
+
+    if (this.props.campaignId) {
+       const query = encodeURIComponent(`"campaignId":"${this.props.campaignId}"`);
+       this.requestUrl = `${this.requestUrl}&query={${query}}`;
+    } else if (this.props.conversationId) {
        const query = encodeURIComponent(`"conversationId":"${this.props.conversationId}"`);
        this.requestUrl = `${this.requestUrl}&query={${query}}`;
     } else if (this.props.requestId) {


### PR DESCRIPTION
Picks up after #16 (needs #16 reviewed first)

Adds two new paths:
- `/campaigns`: Index of all active Gambit Campaigns
- `/campaigns/:id`: Campaign Detail that displays cached templates, filters messages by campaign

TODO: Add index to `Messages.campaignId` in Conversations API