### PR TITLE
Display Northstar User on Conversation Detail 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ DS_GAMBIT_CONVERSATIONS_API_BASEURI=https://gambit-conversations-staging.herokua
 DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_NAME=puppet
 DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_PASS=secret
 
+DS_NORTHSTAR_API_BASEURI=https://northstar-thor.dosomething.org/v1
+DS_NORTHSTAR_API_KEY=secret
+
 ## Client
 
 ## Use REACT_APP_ prefix to access config variables in our React components 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ npm start
 
 The React app is configured to proxy backend requests to the local Node server. (See [`"proxy"` config](client/package.json))
 
+**Note:** If the server port changes, the client package.json proxy must be updated as well.
+
 In a separate terminal from the API server, start the UI:
 
 ```bash

--- a/client/src/Components/CampaignDetail.js
+++ b/client/src/Components/CampaignDetail.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Request from 'react-http-request';
-import { Col, ControlLabel, Form, FormControl, FormGroup, Grid, PageHeader, Tab, Tabs, Table } from 'react-bootstrap';
+import { Col, Grid, PageHeader, Panel, Row, Tab, Tabs, Table } from 'react-bootstrap';
 import MessageList from './MessageList';
 import RequestError from './RequestError';
 import RequestLoading from './RequestLoading';
@@ -29,8 +29,8 @@ export default class CampaignDetail extends React.Component {
         <Tab eventKey={0} title="Messages"><br />
           <MessageList campaignId={this.campaignId} />
         </Tab>
-        <Tab eventKey={1} title="Details"><br />
-          { this.renderDetails(campaign) }
+        <Tab eventKey={1} title="Templates"><br />
+          { this.renderTemplates(campaign.templates) }
         </Tab>   
       </Tabs>
     );
@@ -55,6 +55,8 @@ export default class CampaignDetail extends React.Component {
               return (
                 <div>                                  
                   <PageHeader>{campaign.title} <small></small></PageHeader>
+                  <h4>{campaign.tagline}</h4>
+                  { this.renderDetails(campaign) }
                   { this.renderNav(campaign) }
                 </div>
               );
@@ -67,28 +69,16 @@ export default class CampaignDetail extends React.Component {
 
   renderDetails(campaign) {
     return (
-      <div>
-        <Form horizontal>
-          <FormGroup>
-            <Col sm={2}>
-              <ControlLabel>Keywords</ControlLabel>
-            </Col>
-            <Col sm={10}>
-              <FormControl.Static>{ campaign.keywords.join(',') }</FormControl.Static>
-            </Col>
-          </FormGroup>
-          <FormGroup>
-            <Col sm={2}>
-              <ControlLabel>Status</ControlLabel>
-            </Col>
-            <Col sm={10}>
-              <FormControl.Static>{ campaign.status }</FormControl.Static>
-            </Col>
-          </FormGroup>
-        </Form>
-        <h2>Templates</h2>
-        { this.renderTemplates(campaign.templates) }
-      </div>
+      <Panel>
+        <Row>
+          <Col sm={6}>
+            <label>Keywords:</label> {campaign.keywords.join(', ')}
+          </Col>
+          <Col sm={6}>
+            <label>Status:</label> {campaign.status}
+          </Col>
+        </Row>
+      </Panel>
     );
   }
 

--- a/client/src/Components/ConversationDetail.js
+++ b/client/src/Components/ConversationDetail.js
@@ -44,8 +44,8 @@ export default class ConversationDetail extends React.Component {
     let label;
     if (conversation.paused) {
       label =  <small><Label>paused</Label></small>;
-    
     }
+
     return (
       <Grid>
         <PageHeader>{ conversation.platformUserId } {label}</PageHeader>
@@ -82,7 +82,7 @@ export default class ConversationDetail extends React.Component {
         </Row>
         <Row>
           <Col sm={6}>
-            Joined {registrationDate} {registrationSource}
+            <label>Joined:</label> {registrationDate} {registrationSource}
           </Col>
         </Row>
       </Panel>

--- a/client/src/Components/ConversationDetail.js
+++ b/client/src/Components/ConversationDetail.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import Request from 'react-http-request';
-import { Col, ControlLabel, Form, FormControl, FormGroup, Grid, PageHeader } from 'react-bootstrap';
+import { Col, Panel, Grid, Label, PageHeader, Row } from 'react-bootstrap';
+import Moment from 'react-moment';
 import MessageList from './MessageList';
 import RequestError from './RequestError';
 import RequestLoading from './RequestLoading';
 
 const helpers = require('../helpers');
+const config = require('../config');
 
 export default class ConversationDetail extends React.Component {
   constructor(props) {
@@ -39,37 +41,51 @@ export default class ConversationDetail extends React.Component {
   }
 
   renderDetail(conversation) {
+    let label;
+    if (conversation.paused) {
+      label =  <small><Label>paused</Label></small>;
+    
+    }
     return (
       <Grid>
-        <PageHeader>{ conversation.platformUserId } <small>{ conversation.platform } </small></PageHeader>
-        <Form horizontal>
-          <FormGroup>
-            <Col sm={2}>
-              <ControlLabel>Conversation Id</ControlLabel>
-            </Col>
-            <Col sm={10}>
-              <FormControl.Static>{ conversation._id }</FormControl.Static>
-            </Col>
-          </FormGroup>
-          <FormGroup>
-            <Col sm={2}>
-              <ControlLabel>Topic</ControlLabel>
-            </Col>
-            <Col sm={10}>
-              <FormControl.Static>{ conversation.topic }</FormControl.Static>
-            </Col>
-          </FormGroup>
-          <FormGroup>
-            <Col sm={2}>
-              <ControlLabel>Is Paused</ControlLabel>
-            </Col>
-            <Col sm={10}>
-              <FormControl.Static>{ conversation.paused ? 'yes' : 'no' }</FormControl.Static>
-            </Col>
-          </FormGroup>
-        </Form>
+        <PageHeader>{ conversation.platformUserId } {label}</PageHeader>
+        {conversation.user ? this.renderUser(conversation.user) : ''}
         <MessageList conversationId={this.conversationId} />
       </Grid>
+    );
+  }
+
+  renderUser(user) {
+    const lastMessagedDate = <Moment format={config.dateFormat}>{ user.last_messaged_at }</Moment>;
+    const registrationDate = <Moment format="MM/DD/YY">{ user.created_at }</Moment>;
+    let registrationSource;
+    if (user.source) {
+      registrationSource = `via ${user.source}`;
+    }
+    return (
+      <Panel>
+        <Row>
+          <Col sm={6}>
+            <label>User:</label> {user.id}
+          </Col>
+          <Col sm={6}>
+            <label>SMS status:</label> {user.sms_status}
+          </Col>
+        </Row>
+        <Row>
+          <Col sm={6}>
+            <label>Email:</label> {user.email}
+          </Col>
+          <Col sm={6}>
+            <label>Last inbound message:</label> {lastMessagedDate}
+          </Col>
+        </Row>
+        <Row>
+          <Col sm={6}>
+            Joined {registrationDate} {registrationSource}
+          </Col>
+        </Row>
+      </Panel>
     );
   }
 }

--- a/config/lib/northstar.js
+++ b/config/lib/northstar.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  apiKey: process.env.DS_NORTHSTAR_API_KEY,
+  baseUri: process.env.DS_NORTHSTAR_API_BASEURI,
+};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -10,9 +10,9 @@ const logger = require('heroku-logger');
  * @param  {String} message = 'OK'
  */
 module.exports.sendResponseForError = function (res, err) {
-  let status = err.status;
-  if (!err.status) {
-    status = 500;
+  let code = err.status;
+  if (!code) {
+    code = 500;
   }
   return exports.sendResponseWithStatusCode(res, code, err.message);
 };

--- a/lib/northstar.js
+++ b/lib/northstar.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/**
+ * Imports.
+ */
+const Northstar = require('@dosomething/northstar-js');
+const logger = require('heroku-logger');
+const config = require('../config/lib/northstar');
+
+/**
+ * Setup.
+ */
+let client;
+
+/**
+ * @return {Object}
+ */
+module.exports.createNewClient = function createNewClient() {
+  const loggerMsg = 'northstar.createNewClient';
+  const uri = config.baseUri;
+
+  try {
+    client = new Northstar({
+      baseURI: uri,
+      apiKey: config.apiKey,
+    });
+    logger.info(`${loggerMsg} success`, { uri });
+  } catch (err) {
+    logger.error(`${loggerMsg} error`, { errorMessage: err.message });
+  }
+  return client;
+};
+
+/**
+ * @return {Object}
+ */
+module.exports.getClient = function getClient() {
+  if (!client) {
+    return exports.createNewClient();
+  }
+  return client;
+};
+
+/**
+ * @param {string} mobile
+ * @return {Promise}
+ */
+module.exports.getUserByMobile = function (mobile) {
+  logger.info('getUserByMobile', { mobile });
+
+  return exports.getClient().Users.get('mobile', mobile);
+};

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@dosomething/northstar-js": "git://github.com/DoSomething/northstar-js.git",
     "babel-core": "6.14.0",
     "basic-auth": "^2.0.0",
     "dotenv": "^4.0.0",


### PR DESCRIPTION
* Adds the Northstar JS package to fetch a User for SMS Conversations, and display relevant fields to Gambit (User ID, Paused, SMS Status, Last Messaged At).
* Renders detail info for Campaigns and Conversations with `Panel` and `Row` instead of `FormGroup`.
* Fixes bug in `helpers.sendResponseForError`
