### PR TITLE
Campaign Template permalinks

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,8 +16,8 @@
     "react-moment": "^0.6.4",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",
-    "react-router-hash-link": "^1.1.1",
-    "react-scripts": "1.0.10"
+    "react-scripts": "1.0.10",
+    "react-scrollable-anchor": "^0.5.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "react-moment": "^0.6.4",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",
+    "react-router-hash-link": "^1.1.1",
     "react-scripts": "1.0.10"
   },
   "scripts": {

--- a/client/src/Components/CampaignDetail.js
+++ b/client/src/Components/CampaignDetail.js
@@ -92,7 +92,7 @@ export default class CampaignDetail extends React.Component {
     const templateNames = Object.keys(templates).sort();
     const rows = templateNames.map((template) => {
       return (
-        <tr>
+        <tr key={template} id={template}>
           <td sm={4}><strong>{ template }</strong></td>
           <td sm={6}>{ templates[template].rendered }</td>
           <td sm={2}>{ templates[template].override ? <strong>overridden</strong> : 'default' }</td>

--- a/client/src/Components/CampaignDetail.js
+++ b/client/src/Components/CampaignDetail.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Request from 'react-http-request';
+import { HashLink as Link } from 'react-router-hash-link';
 import { Col, Grid, PageHeader, Panel, Row, Tab, Tabs, Table } from 'react-bootstrap';
 import MessageList from './MessageList';
 import RequestError from './RequestError';
@@ -13,6 +14,7 @@ export default class CampaignDetail extends React.Component {
     super(props);
 
     this.campaignId = this.props.match.params.campaignId;
+    this.url = `/campaigns/${this.campaignId}`;
     this.requestUrl = helpers.getCampaignIdUrl(this.campaignId);
   }
 
@@ -90,12 +92,17 @@ export default class CampaignDetail extends React.Component {
 
   renderTemplates(templates) {
     const templateNames = Object.keys(templates).sort();
-    const rows = templateNames.map((template) => {
+    const rows = templateNames.map((templateName) => {
+      const url = `${this.url}#${templateName}`;
       return (
-        <tr key={template} id={template}>
-          <td sm={4}><strong>{ template }</strong></td>
-          <td sm={6}>{ templates[template].rendered }</td>
-          <td sm={2}>{ templates[template].override ? <strong>overridden</strong> : 'default' }</td>
+        <tr key={templateName} id={templateName}>
+          <td sm={4}>
+            <Link to={url}><strong>{ templateName }</strong></Link>
+          </td>
+          <td sm={6}>{ templates[templateName].rendered }</td>
+          <td sm={2}>
+            { templates[templateName].override ? <strong>overridden</strong> : 'default' }
+          </td>
         </tr>
       );
     });

--- a/client/src/Components/CampaignDetail.js
+++ b/client/src/Components/CampaignDetail.js
@@ -5,6 +5,7 @@ import MessageList from './MessageList';
 import RequestError from './RequestError';
 import RequestLoading from './RequestLoading';
 
+const queryString = require('query-string');
 const helpers = require('../helpers');
 
 export default class CampaignDetail extends React.Component {
@@ -24,14 +25,19 @@ export default class CampaignDetail extends React.Component {
   }
 
   renderNav(campaign) {
+    const queryParams = queryString.parse(window.location.search);
+    let defaultActiveKey = 0;
+    if (queryParams.skip) {
+      defaultActiveKey = 1;
+    }
     return (
-      <Tabs defaultActiveKey={0} animation={false} id="campaign-tabs">
-        <Tab eventKey={0} title="Messages"><br />
-          <MessageList campaignId={this.campaignId} />
-        </Tab>
-        <Tab eventKey={1} title="Templates"><br />
+      <Tabs defaultActiveKey={defaultActiveKey} animation={false} id="campaign-tabs">
+        <Tab eventKey={0} title="Templates"><br />
           { this.renderTemplates(campaign.templates) }
         </Tab>   
+        <Tab eventKey={1} title="Messages"><br />
+          <MessageList campaignId={this.campaignId} />
+        </Tab>
       </Tabs>
     );
   }

--- a/client/src/Components/CampaignDetail.js
+++ b/client/src/Components/CampaignDetail.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Request from 'react-http-request';
-import { HashLink as Link } from 'react-router-hash-link';
-import { Col, Grid, PageHeader, Panel, Row, Tab, Tabs, Table } from 'react-bootstrap';
+import { Col, Grid, PageHeader, Panel, Row, Tab, Tabs } from 'react-bootstrap';
+import CampaignTemplate from './CampaignTemplate';
 import MessageList from './MessageList';
 import RequestError from './RequestError';
 import RequestLoading from './RequestLoading';
@@ -63,7 +63,6 @@ export default class CampaignDetail extends React.Component {
               return (
                 <div>                                  
                   <PageHeader>{campaign.title} <small></small></PageHeader>
-                  <h4>{campaign.tagline}</h4>
                   { this.renderDetails(campaign) }
                   { this.renderNav(campaign) }
                 </div>
@@ -79,6 +78,9 @@ export default class CampaignDetail extends React.Component {
     return (
       <Panel>
         <Row>
+          <Col sm={12}><label>Tagline:</label> {campaign.tagline}</Col>
+        </Row>
+        <Row>
           <Col sm={6}>
             <label>Keywords:</label> {campaign.keywords.join(', ')}
           </Col>
@@ -91,23 +93,14 @@ export default class CampaignDetail extends React.Component {
   }
 
   renderTemplates(templates) {
-    const templateNames = Object.keys(templates).sort();
+    const templateNames = Object.keys(templates);
     const rows = templateNames.map((templateName) => {
-      const url = `${this.url}#${templateName}`;
-      return (
-        <tr key={templateName} id={templateName}>
-          <td sm={4}>
-            <Link to={url}><strong>{ templateName }</strong></Link>
-          </td>
-          <td sm={6}>{ templates[templateName].rendered }</td>
-          <td sm={2}>
-            { templates[templateName].override ? <strong>overridden</strong> : 'default' }
-          </td>
-        </tr>
-      );
+      return <CampaignTemplate key={templateName} name={templateName} data={templates[templateName]} />
     });
-    return <Table striped>
-      <tbody>{ rows }</tbody>
-    </Table>;
+    return (
+      <Grid>
+        {rows}
+      </Grid>
+    );
   }
 }

--- a/client/src/Components/CampaignTemplate.js
+++ b/client/src/Components/CampaignTemplate.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import ScrollableAnchor from 'react-scrollable-anchor'
+import { Panel, Row } from 'react-bootstrap';
+
+export default class CampaignTemplate extends React.Component {
+  render() {
+    const name = this.props.name;
+    const data = this.props.data;
+    let suffix = '';
+    if (data.override) {
+      suffix = '**';
+    }
+    return (
+      <Row id={name} key={name}>
+        <Panel>
+          <ScrollableAnchor id={name}>
+          <h4><a href={`#${name}`}># {name}{suffix}</a></h4>
+          </ScrollableAnchor>
+          <p>{data.rendered}</p>
+        </Panel>
+      </Row>
+    );
+  }
+}

--- a/client/src/Components/CampaignTemplate.js
+++ b/client/src/Components/CampaignTemplate.js
@@ -14,7 +14,7 @@ export default class CampaignTemplate extends React.Component {
       <Row id={name} key={name}>
         <Panel>
           <ScrollableAnchor id={name}>
-          <h4><a href={`#${name}`}># {name}{suffix}</a></h4>
+            <h4><a href={`#${name}`}># {name}{suffix}</a></h4>
           </ScrollableAnchor>
           <p>{data.rendered}</p>
         </Panel>

--- a/client/src/Components/MessageList.js
+++ b/client/src/Components/MessageList.js
@@ -52,10 +52,7 @@ export default class MessageList extends React.Component {
     let leftPagerItem;
     if (this.skipCount) {
       const prevSkip = this.skipCount - pageSize;
-      let prevUrl = url;
-      if (prevSkip > 0) {
-        prevUrl = `${url}?skip=${prevSkip}`;
-      }
+      const prevUrl = `${url}?skip=${prevSkip}`;
       leftPagerItem = <Pager.Item previous href={ prevUrl }>Previous</Pager.Item>;
     }
 


### PR DESCRIPTION
* Makes the Templates tab the default view of a Campaign Detail (`/campaigns/:id`)
* Adds [`react-scrollable-anchor`](https://www.npmjs.com/package/react-scrollable-anchor) and a `CampaignTemplate` component to link to a specific template row, e.g. http://gambit-admin-staging.herokuapp.com/campaigns/6620#invalidAskSignupResponse