### PR TITLE
User Signups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,14 +9,13 @@ DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_PASS=secret
 DS_NORTHSTAR_API_BASEURI=https://northstar-thor.dosomething.org/v1
 DS_NORTHSTAR_API_KEY=secret
 
-DS_ROGUE_API_BASEURI=https://rogue-thor.dosomething.org/api/v2
+DS_ROGUE_BASEURI=https://rogue-thor.dosomething.org
 DS_ROGUE_API_KEY=secret
 
 
 ## PROFILE LINKS
 
 DS_AURORA_PROFILE_BASEURI=https://aurora-thor.dosomething.org/users
-DS_ROGUE_PROFILE_BASEURI=https://rogue-thor.dosomething.org/users
 MOBILECOMMONS_PROFILE_BASEURI=https://secure.mobilecommons.com/profiles
 
 ## Client

--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,12 @@ DS_GAMBIT_CONVERSATIONS_API_BASEURI=https://gambit-conversations-staging.herokua
 DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_NAME=puppet
 DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_PASS=secret
 
-
 DS_NORTHSTAR_API_BASEURI=https://northstar-thor.dosomething.org/v1
 DS_NORTHSTAR_API_KEY=secret
+
+DS_ROGUE_API_BASEURI=https://rogue-thor.dosomething.org/api/v2
+DS_ROGUE_API_KEY=secret
+
 
 ## PROFILE LINKS
 

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-react": "^7.1.0",
     "moment": "^2.18.1",
+    "prop-types": "^15.6.0",
     "query-string": "^5.0.0",
     "react": "^15.6.1",
     "react-bootstrap": "^0.31.0",

--- a/client/src/Components/ConversationDetail.js
+++ b/client/src/Components/ConversationDetail.js
@@ -11,16 +11,30 @@ const helpers = require('../helpers');
 const config = require('../config');
 
 class ConversationDetail extends React.Component {
+  static postLabel(status) {
+    let style = 'warning';
+    if (status === 'rejected') {
+      style = 'danger';
+    } else if (status === 'accepted') {
+      style = 'success';
+    }
+    return <Label bsStyle={style}>{status}</Label>;
+  }
+
   static renderSignup(signup) {
-    const createdAt = <Moment format={config.dateFormat}>{signup.created_at}</Moment>;
+    const signupDate = <Moment format={'MM/DD/YY'}>{signup.created_at}</Moment>;
     let signupSource = null;
     if (signup.signup_source) {
-      signupSource = <p>{signup.signup_source}</p>;
+      signupSource = `via ${signup.signup_source}`;
     }
+
     let posts = null;
     const numPosts = signup.posts.data.length;
     if (numPosts) {
       posts = signup.posts.data.map((post, index) => {
+        const postDate = <Moment format={config.dateFormat}>{post.created_at}</Moment>;
+        const status = ConversationDetail.postLabel(post.status);
+
         let whyParticipated = null;
         if (index === numPosts - 1) {
           whyParticipated = (
@@ -42,17 +56,21 @@ class ConversationDetail extends React.Component {
             </ListGroupItem>
             {whyParticipated}
             <ListGroupItem>
-              <strong>Status:</strong> {post.status}
+              <strong>Submitted:</strong> {postDate} {status}
             </ListGroupItem>
           </ListGroup>
         );
       });
     }
+    const campaignId = signup.campaign_id;
+    const campaignLink = <a href={`/campaigns/${campaignId}`}>{campaignId}</a>;
     return (
       <tr key={signup.signup_id}>
-        <td>{signup.signup_id}</td>
-        <td>{signup.campaign_id}</td>
-        <td>{createdAt} {signupSource}</td>
+        <td>
+          <strong><a href={signup.url}>{signup.signup_id}</a></strong>
+          <div>{signupDate} {signupSource}</div>
+        </td>
+        <td>{campaignLink}</td>
         <td>{posts}</td>
       </tr>
     );
@@ -64,9 +82,8 @@ class ConversationDetail extends React.Component {
       <Table>
         <thead>
           <tr>
-            <th width={100}>Signup</th>
+            <th width={300}>Signup</th>
             <th width={100}>Campaign</th>
-            <th width={200}>Created</th>
             <th>Posts</th>
           </tr>
         </thead>

--- a/client/src/Components/ConversationDetail.js
+++ b/client/src/Components/ConversationDetail.js
@@ -32,7 +32,11 @@ class ConversationDetail extends React.Component {
     const numPosts = signup.posts.data.length;
     if (numPosts) {
       posts = signup.posts.data.map((post, index) => {
-        const postDate = <Moment format={config.dateFormat}>{post.created_at}</Moment>;
+        const postDate = <Moment format={'MM/DD/YY'}>{post.created_at}</Moment>;
+        let postSource = null;
+        if (post.source) {
+          postSource = ` via ${post.source}`;
+        }
         const status = ConversationDetail.postLabel(post.status);
 
         let whyParticipated = null;
@@ -56,7 +60,7 @@ class ConversationDetail extends React.Component {
             </ListGroupItem>
             {whyParticipated}
             <ListGroupItem>
-              <strong>Submitted:</strong> {postDate} {status}
+              <strong>Submitted:</strong> {postDate}{postSource} {status}
             </ListGroupItem>
           </ListGroup>
         );
@@ -82,8 +86,8 @@ class ConversationDetail extends React.Component {
       <Table>
         <thead>
           <tr>
-            <th width={300}>Signup</th>
-            <th width={100}>Campaign</th>
+            <th width={250}>Signup</th>
+            <th width={150}>Campaign</th>
             <th>Posts</th>
           </tr>
         </thead>

--- a/client/src/Components/ConversationDetail.js
+++ b/client/src/Components/ConversationDetail.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import Request from 'react-http-request';
-import { Col, Panel, Grid, Image, Label, ListGroup, ListGroupItem, PageHeader, Row, Tab, Table, Tabs} from 'react-bootstrap';
+import { Col, Panel, Grid, Image, Label, ListGroup, ListGroupItem, PageHeader, Row, Tab, Table, Tabs } from 'react-bootstrap';
 import Moment from 'react-moment';
+import PropTypes from 'prop-types';
 import MessageList from './MessageList';
 import RequestError from './RequestError';
 import RequestLoading from './RequestLoading';
@@ -9,55 +10,9 @@ import RequestLoading from './RequestLoading';
 const helpers = require('../helpers');
 const config = require('../config');
 
-export default class ConversationDetail extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.conversationId = this.props.match.params.conversationId;
-    this.requestUrl = helpers.getConversationIdUrl(this.conversationId);
-  }
-
-  render() {
-    return (
-      <Request
-        url={this.requestUrl}
-        method='get'
-        accept='application/json'
-        verbose={true}
-      >
-        {
-          ({error, result, loading}) => {
-            if (loading) {
-              return <RequestLoading />;
-            } else if (error) {
-              return <RequestError error={error} />
-            } else {
-              return this.renderDetail(result.body.data);
-            }
-          }
-        }
-      </Request>
-    );
-  }
-
-  renderNav(conversation) {
-    const numSignups = conversation.user.signups.meta.pagination.total;
-    const signupsLabel = `Signups (${numSignups})`;
-
-    return (
-      <Tabs defaultActiveKey={0} animation={false} id="campaign-tabs">
-        <Tab eventKey={0} title="Messages"><br />
-           <MessageList conversationId={this.conversationId} />
-        </Tab>
-        <Tab eventKey={1} title={signupsLabel}><br />
-          { this.renderSignups(conversation.user.signups) }
-        </Tab>
-      </Tabs>
-    );
-  }
-
-  renderSignup(signup) {
-    let createdAt = <Moment format={config.dateFormat}>{signup.created_at}</Moment>;
+class ConversationDetail extends React.Component {
+  static renderSignup(signup) {
+    const createdAt = <Moment format={config.dateFormat}>{signup.created_at}</Moment>;
     let signupSource = null;
     if (signup.signup_source) {
       signupSource = <p>{signup.signup_source}</p>;
@@ -66,12 +21,11 @@ export default class ConversationDetail extends React.Component {
     const numPosts = signup.posts.data.length;
     if (numPosts) {
       posts = signup.posts.data.map((post, index) => {
-        console.log(post);
         let whyParticipated = null;
         if (index === numPosts - 1) {
           whyParticipated = (
             <ListGroupItem>
-              <label>Why Participated:</label> {signup.why_participated}
+              <strong>Why Participated:</strong> {signup.why_participated}
             </ListGroupItem>
           );
         }
@@ -81,14 +35,14 @@ export default class ConversationDetail extends React.Component {
               <Image src={post.media.url} height={200} />
             </ListGroupItem>
             <ListGroupItem>
-              <label>Caption:</label> {post.media.caption}
+              <strong>Caption:</strong> {post.media.caption}
             </ListGroupItem>
             <ListGroupItem>
-              <label>Quantity:</label> {signup.quantity}
+              <strong>Quantity:</strong> {signup.quantity}
             </ListGroupItem>
             {whyParticipated}
             <ListGroupItem>
-              <label>Status:</label> {post.status}
+              <strong>Status:</strong> {post.status}
             </ListGroupItem>
           </ListGroup>
         );
@@ -104,48 +58,33 @@ export default class ConversationDetail extends React.Component {
     );
   }
 
-  renderSignups(signups) {
-    const rows = signups.data.map(signup => this.renderSignup(signup));
+  static renderSignups(signups) {
+    const rows = signups.data.map(signup => ConversationDetail.renderSignup(signup));
     return (
       <Table>
-      <thead>
-        <tr>
-          <th width={100}>Signup</th>
-          <th width={100}>Campaign</th>
-          <th width={200}>Created</th>
-          <th>Posts</th>
-        </tr>
-      </thead>
-      <tbody>
-        {rows}
-      </tbody>
+        <thead>
+          <tr>
+            <th width={100}>Signup</th>
+            <th width={100}>Campaign</th>
+            <th width={200}>Created</th>
+            <th>Posts</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows}
+        </tbody>
       </Table>
     );
   }
 
-  renderDetail(conversation) {
-    let label;
-    if (conversation.paused) {
-      label =  <small><Label>paused</Label></small>;
-    }
-
-    return (
-      <Grid>
-        <PageHeader>{ conversation.platformUserId } {label}</PageHeader>
-        {conversation.user ? this.renderUser(conversation.user) : ''}
-        {this.renderNav(conversation)}
-      </Grid>
-    );
-  }
-
-  renderUser(user) {
+  static renderUser(user) {
     const lastMessagedDate = <Moment format={config.dateFormat}>{ user.last_messaged_at }</Moment>;
     const registrationDate = <Moment format="MM/DD/YY">{ user.created_at }</Moment>;
     let registrationSource;
     if (user.source) {
       registrationSource = `via ${user.source}`;
     }
-
+    const auroraLink = <a href={user.links.aurora}>Aurora</a>;
     const rogueLink = <a href={user.links.rogue}>Rogue</a>;
     let mobileCommonsLink = null;
     if (user.links.mobilecommons) {
@@ -156,29 +95,97 @@ export default class ConversationDetail extends React.Component {
       <Panel>
         <Row>
           <Col sm={6}>
-            <label>User:</label> <a href={user.links.aurora}><code>{user.id}</code></a>
+            <strong>User:</strong> <a href={user.links.aurora}><code>{user.id}</code></a>
           </Col>
           <Col sm={6}>
-            <label>SMS status:</label> {user.sms_status}
-          </Col>
-        </Row>
-        <Row>
-          <Col sm={6}>
-            <label>Email:</label> {user.email}
-          </Col>
-          <Col sm={6}>
-            <label>Last inbound message:</label> {lastMessagedDate}
+            <strong>SMS status:</strong> {user.sms_status}
           </Col>
         </Row>
         <Row>
           <Col sm={6}>
-            <label>Joined:</label> {registrationDate} {registrationSource}
+            <strong>Email:</strong> {user.email}
           </Col>
           <Col sm={6}>
-            <label>Profiles:</label> <a href={user.links.aurora}>Aurora</a> | {rogueLink} {mobileCommonsLink}
+            <strong>Last inbound message:</strong> {lastMessagedDate}
+          </Col>
+        </Row>
+        <Row>
+          <Col sm={6}>
+            <strong>Joined:</strong> {registrationDate} {registrationSource}
+          </Col>
+          <Col sm={6}>
+            <strong>Profiles:</strong> {auroraLink}  | {rogueLink} {mobileCommonsLink}
           </Col>
         </Row>
       </Panel>
     );
   }
+
+  constructor(props) {
+    super(props);
+
+    this.conversationId = this.props.match.params.conversationId;
+    this.requestUrl = helpers.getConversationIdUrl(this.conversationId);
+  }
+
+  renderNav(conversation) {
+    const numSignups = conversation.user.signups.meta.pagination.total;
+    const signupsLabel = `Signups (${numSignups})`;
+
+    return (
+      <Tabs defaultActiveKey={0} animation={false} id="campaign-tabs">
+        <Tab eventKey={0} title="Messages"><br />
+          <MessageList conversationId={this.conversationId} />
+        </Tab>
+        <Tab eventKey={1} title={signupsLabel}><br />
+          { ConversationDetail.renderSignups(conversation.user.signups) }
+        </Tab>
+      </Tabs>
+    );
+  }
+
+  renderDetail(conversation) {
+    let label;
+    if (conversation.paused) {
+      label = <small><Label>paused</Label></small>;
+    }
+
+    return (
+      <Grid>
+        <PageHeader>{ conversation.platformUserId } {label}</PageHeader>
+        {conversation.user ? ConversationDetail.renderUser(conversation.user) : ''}
+        {this.renderNav(conversation)}
+      </Grid>
+    );
+  }
+
+  render() {
+    return (
+      <Request
+        url={this.requestUrl}
+        method="get"
+        accept="application/json"
+        verbose
+      >
+        {
+          ({ error, result, loading }) => {
+            if (loading) {
+              return <RequestLoading />;
+            } else if (error) {
+              return <RequestError error={error} />;
+            }
+            return this.renderDetail(result.body.data);
+          }
+        }
+      </Request>
+    );
+  }
 }
+
+ConversationDetail.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({ conversationId: PropTypes.string.isRequired }).isRequired,
+  }).isRequired,
+};
+
+export default ConversationDetail;

--- a/client/src/Components/ConversationDetail.js
+++ b/client/src/Components/ConversationDetail.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Request from 'react-http-request';
-import { Col, Panel, Grid, Label, PageHeader, Row } from 'react-bootstrap';
+import { Col, Panel, Grid, Image, Label, ListGroup, ListGroupItem, PageHeader, Row, Tab, Table, Tabs} from 'react-bootstrap';
 import Moment from 'react-moment';
 import MessageList from './MessageList';
 import RequestError from './RequestError';
@@ -40,6 +40,89 @@ export default class ConversationDetail extends React.Component {
     );
   }
 
+  renderNav(conversation) {
+    const numSignups = conversation.user.signups.meta.pagination.total;
+    const signupsLabel = `Signups (${numSignups})`;
+
+    return (
+      <Tabs defaultActiveKey={0} animation={false} id="campaign-tabs">
+        <Tab eventKey={0} title="Messages"><br />
+           <MessageList conversationId={this.conversationId} />
+        </Tab>
+        <Tab eventKey={1} title={signupsLabel}><br />
+          { this.renderSignups(conversation.user.signups) }
+        </Tab>
+      </Tabs>
+    );
+  }
+
+  renderSignup(signup) {
+    let createdAt = <Moment format={config.dateFormat}>{signup.created_at}</Moment>;
+    let signupSource = null;
+    if (signup.signup_source) {
+      signupSource = <p>{signup.signup_source}</p>;
+    }
+    let posts = null;
+    const numPosts = signup.posts.data.length;
+    if (numPosts) {
+      posts = signup.posts.data.map((post, index) => {
+        console.log(post);
+        let whyParticipated = null;
+        if (index === numPosts - 1) {
+          whyParticipated = (
+            <ListGroupItem>
+              <label>Why Participated:</label> {signup.why_participated}
+            </ListGroupItem>
+          );
+        }
+        return (
+          <ListGroup key={post.id}>
+            <ListGroupItem>
+              <Image src={post.media.url} height={200} />
+            </ListGroupItem>
+            <ListGroupItem>
+              <label>Caption:</label> {post.media.caption}
+            </ListGroupItem>
+            <ListGroupItem>
+              <label>Quantity:</label> {signup.quantity}
+            </ListGroupItem>
+            {whyParticipated}
+            <ListGroupItem>
+              <label>Status:</label> {post.status}
+            </ListGroupItem>
+          </ListGroup>
+        );
+      });
+    }
+    return (
+      <tr key={signup.signup_id}>
+        <td>{signup.signup_id}</td>
+        <td>{signup.campaign_id}</td>
+        <td>{createdAt} {signupSource}</td>
+        <td>{posts}</td>
+      </tr>
+    );
+  }
+
+  renderSignups(signups) {
+    const rows = signups.data.map(signup => this.renderSignup(signup));
+    return (
+      <Table>
+      <thead>
+        <tr>
+          <th width={100}>Signup</th>
+          <th width={100}>Campaign</th>
+          <th width={200}>Created</th>
+          <th>Posts</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows}
+      </tbody>
+      </Table>
+    );
+  }
+
   renderDetail(conversation) {
     let label;
     if (conversation.paused) {
@@ -50,7 +133,7 @@ export default class ConversationDetail extends React.Component {
       <Grid>
         <PageHeader>{ conversation.platformUserId } {label}</PageHeader>
         {conversation.user ? this.renderUser(conversation.user) : ''}
-        <MessageList conversationId={this.conversationId} />
+        {this.renderNav(conversation)}
       </Grid>
     );
   }

--- a/client/src/Components/ConversationDetail.js
+++ b/client/src/Components/ConversationDetail.js
@@ -40,7 +40,9 @@ class ConversationDetail extends React.Component {
         const status = ConversationDetail.postLabel(post.status);
 
         let whyParticipated = null;
-        if (index === numPosts - 1) {
+        // Posts are ordered by ascending created date. We only ask for Why Participated if it's
+        // the User's first post for the Campaign.
+        if (index === 0) {
           whyParticipated = (
             <ListGroupItem>
               <strong>Why Participated:</strong> {signup.why_participated}
@@ -150,17 +152,23 @@ class ConversationDetail extends React.Component {
   }
 
   renderNav(conversation) {
-    const numSignups = conversation.user.signups.meta.pagination.total;
-    const signupsLabel = `Signups (${numSignups})`;
+    let signupsTab = null;
+    if (conversation.user) {
+      const numSignups = conversation.user.signups.meta.pagination.total;
+      const signupsLabel = `Signups (${numSignups})`;
+      signupsTab = (
+        <Tab eventKey={1} title={signupsLabel}><br />
+          { ConversationDetail.renderSignups(conversation.user.signups) }
+        </Tab>
+      );
+    }
 
     return (
       <Tabs defaultActiveKey={0} animation={false} id="campaign-tabs">
         <Tab eventKey={0} title="Messages"><br />
           <MessageList conversationId={this.conversationId} />
         </Tab>
-        <Tab eventKey={1} title={signupsLabel}><br />
-          { ConversationDetail.renderSignups(conversation.user.signups) }
-        </Tab>
+        {signupsTab}
       </Tabs>
     );
   }

--- a/config/lib/rogue.js
+++ b/config/lib/rogue.js
@@ -2,5 +2,5 @@
 
 module.exports = {
   apiKey: process.env.DS_ROGUE_API_KEY,
-  baseUri: process.env.DS_ROGUE_API_BASEURI,
+  baseUri: process.env.DS_ROGUE_BASEURI,
 };

--- a/config/lib/rogue.js
+++ b/config/lib/rogue.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  apiKey: process.env.DS_ROGUE_API_KEY,
+  baseUri: process.env.DS_ROGUE_API_BASEURI,
+};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -59,7 +59,17 @@ module.exports.getMobileCommonsUrlForMobileCommonsId = function (mobileCommonsId
  * @return {string}
  */
 module.exports.getRogueUrlForUserId = function (userId) {
-  const baseUri = process.env.DS_ROGUE_PROFILE_BASEURI;
-  const result = `${baseUri}/${userId}`;
+  const baseUri = process.env.DS_ROGUE_BASEURI;
+  const result = `${baseUri}/users/${userId}`;
+  return result;
+};
+
+/**
+ * @param {string} signupId
+ * @return {string}
+ */
+module.exports.getRogueUrlForSignupId = function (signupId) {
+  const baseUri = process.env.DS_ROGUE_BASEURI;
+  const result = `${baseUri}/signups/${signupId}`;
   return result;
 };

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const superagent = require('superagent');
+const logger = require('heroku-logger');
+const config = require('../config/lib/rogue');
+
+/**
+ * @param {string} path
+ * @param {object} query
+ * @return {Promise}
+ */
+function executeGet(path, query) {
+  const url = `${config.baseUri}/${path}`;
+  logger.info('executeGet', { url, query });
+
+  return superagent.get(url)
+    .query(query)
+    .then(res => res.body)
+    .catch(err => err);
+}
+
+
+module.exports.getSignupsForUserId = function (userId) {
+  const query = { 'filter[northstar_id]': userId };
+  return executeGet('activity', query);
+};

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -25,5 +25,5 @@ module.exports.getSignupsForUserId = function (userId) {
     'filter[northstar_id]': userId,
     orderBy: 'desc',
   };
-  return executeGet('activity', query);
+  return executeGet('api/v2/activity', query);
 };

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -21,6 +21,9 @@ function executeGet(path, query) {
 
 
 module.exports.getSignupsForUserId = function (userId) {
-  const query = { 'filter[northstar_id]': userId };
+  const query = {
+    'filter[northstar_id]': userId,
+    orderBy: 'desc',
+  };
   return executeGet('activity', query);
 };

--- a/routes/gambit-conversations.js
+++ b/routes/gambit-conversations.js
@@ -3,6 +3,7 @@
 const express = require('express');
 const conversations = require('../lib/gambit-conversations');
 const northstar = require('../lib/northstar');
+const rogue = require('../lib/rogue');
 const helpers = require('../lib/helpers');
 
 const router = express.Router();
@@ -36,6 +37,10 @@ router.get('/conversations/:id', (req, res) => {
         const url = helpers.getMobileCommonsUrlForMobileCommonsId(user.mobilecommons_id);
         req.data.user.links.mobilecommons = url;
       }
+      return rogue.getSignupsForUserId(userId);
+    })
+    .then((apiRes) => {
+      req.data.user.signups = apiRes;
       return res.send({ data: req.data });
     })
     .catch(err => helpers.sendResponseForError(res, err));

--- a/routes/gambit-conversations.js
+++ b/routes/gambit-conversations.js
@@ -41,6 +41,9 @@ router.get('/conversations/:id', (req, res) => {
     })
     .then((apiRes) => {
       req.data.user.signups = apiRes;
+      req.data.user.signups.data.forEach((signup, index) => {
+        req.data.user.signups.data[index].url = helpers.getRogueUrlForSignupId(signup.signup_id);
+      });
       return res.send({ data: req.data });
     })
     .catch(err => helpers.sendResponseForError(res, err));


### PR DESCRIPTION
Branching from #28:
* This PR adds a Signups tab to the `ConversationDetail` component, querying the Rogue API to display the last 20 signups for the Conversation User. This helps make it easier for Gambit devs to test their code (did the Signup work?), and admins investigate support questions.
* Fixes `ConversationDetail` lint errors.

I'll be adding the config variables to staging and deploy this branch to confirm works as expected, and also edit this PR base to `master` once #28 is merged.