### PR TITLE
Broadcasts

### DIFF
--- a/client/src/Components/Broadcast/Broadcast.js
+++ b/client/src/Components/Broadcast/Broadcast.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { Col, Form, FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
 
 function renderRow(label, data) {
@@ -11,14 +12,17 @@ function renderRow(label, data) {
 }
 
 const Broadcast = (data) => {
-  const webhook = data.broadcast.webhook;
+  const broadcast = data.broadcast;
+  const webhook = broadcast.webhook;
   const webhookBody = JSON.stringify(webhook.body, null, 2);
+  const campaignId = broadcast.campaign.campaignId;
+  const campaignLink = `/campaigns/${campaignId}`;
 
   return (
     <div>
       <Form horizontal>
-        {renderRow('Campaign', data.broadcast.campaign.campaignId)}
-        {renderRow('Message', data.broadcast.broadcast.message)}
+        {renderRow('Campaign', <Link to={campaignLink}>{campaignId}</Link>)}
+        {renderRow('Message', broadcast.broadcast.message)}
       </Form>
       <h3>Customer.io settings</h3>
       <Form horizontal>

--- a/client/src/Components/Broadcast/Broadcast.js
+++ b/client/src/Components/Broadcast/Broadcast.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Col, Form, FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
+
+function renderRow(label, data) {
+  return (
+    <FormGroup>
+      <Col sm={2}><ControlLabel>{label}</ControlLabel></Col>
+      <Col sm={10}><FormControl.Static>{data}</FormControl.Static></Col>
+    </FormGroup>
+  );
+}
+
+const Broadcast = (data) => {
+  const webhook = data.broadcast.webhook;
+  const webhookBody = JSON.stringify(webhook.body, null, 2);
+
+  return (
+    <div>
+      <Form horizontal>
+        {renderRow('Campaign', data.broadcast.campaign.campaignId)}
+        {renderRow('Message', data.broadcast.broadcast.message)}
+      </Form>
+      <h3>Customer.io settings</h3>
+      <Form horizontal>
+        {renderRow('URL', <code>{webhook.url}</code>)}
+        {renderRow('Body', <code>{webhookBody}</code>)}
+      </Form>
+    </div>
+  );
+};
+
+export default Broadcast;

--- a/client/src/Components/Broadcast/Broadcast.js
+++ b/client/src/Components/Broadcast/Broadcast.js
@@ -33,8 +33,8 @@ const Broadcast = (props) => {
       </Form>
       <h3>Stats</h3>
       <Form horizontal>
-        {renderRow('Outbound messages', broadcast.stats.totalOutboundMessages)}
-        {renderRow('Inbound messages', broadcast.stats.totalInboundMessages)}
+        {renderRow('Outbound messages', broadcast.stats.outbound.total.toLocaleString())}
+        {renderRow('Inbound messages', broadcast.stats.inbound.total.toLocaleString())}
       </Form>
       <h3>Customer.io settings</h3>
       <Form horizontal>

--- a/client/src/Components/Broadcast/Broadcast.js
+++ b/client/src/Components/Broadcast/Broadcast.js
@@ -11,23 +11,30 @@ function renderRow(label, data) {
   );
 }
 
-const Broadcast = (data) => {
-  const broadcast = data.broadcast;
+const Broadcast = (props) => {
+  const broadcast = props.broadcast;
   const webhook = broadcast.webhook;
   const webhookBody = JSON.stringify(webhook.body, null, 2);
-  const campaignId = broadcast.campaign.campaignId;
-  const campaignLink = `/campaigns/${campaignId}`;
+  let context = null;
+  if (broadcast.topic) {
+    context = renderRow('Topic', broadcast.topic);
+  } else {
+    const campaignId = broadcast.campaignId;
+    const campaignLink = `/campaigns/${campaignId}`;
+    context = renderRow('Campaign', <Link to={campaignLink}>{campaignId}</Link>);
+  }
+
 
   return (
     <div>
       <Form horizontal>
-        {renderRow('Campaign', <Link to={campaignLink}>{campaignId}</Link>)}
-        {renderRow('Message', broadcast.broadcast.message)}
+        {context}
+        {renderRow('Message', broadcast.message)}
       </Form>
       <h3>Customer.io settings</h3>
       <Form horizontal>
         {renderRow('URL', webhook.url)}
-        {renderRow('Body', <code>{webhookBody}</code>)}
+        {renderRow('Body', <pre><code>{webhookBody}</code></pre>)}
       </Form>
     </div>
   );

--- a/client/src/Components/Broadcast/Broadcast.js
+++ b/client/src/Components/Broadcast/Broadcast.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Col, Form, FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
+import PropTypes from 'prop-types';
 
 function renderRow(label, data) {
   return (
@@ -24,7 +25,6 @@ const Broadcast = (props) => {
     context = renderRow('Campaign', <Link to={campaignLink}>{campaignId}</Link>);
   }
 
-
   return (
     <div>
       <Form horizontal>
@@ -38,6 +38,10 @@ const Broadcast = (props) => {
       </Form>
     </div>
   );
+};
+
+Broadcast.propTypes = {
+  broadcast: PropTypes.shape.isRequired,
 };
 
 export default Broadcast;

--- a/client/src/Components/Broadcast/Broadcast.js
+++ b/client/src/Components/Broadcast/Broadcast.js
@@ -31,6 +31,11 @@ const Broadcast = (props) => {
         {context}
         {renderRow('Message', broadcast.message)}
       </Form>
+      <h3>Stats</h3>
+      <Form horizontal>
+        {renderRow('Outbound messages', broadcast.stats.totalOutboundMessages)}
+        {renderRow('Inbound messages', broadcast.stats.totalInboundMessages)}
+      </Form>
       <h3>Customer.io settings</h3>
       <Form horizontal>
         {renderRow('URL', webhook.url)}

--- a/client/src/Components/Broadcast/Broadcast.js
+++ b/client/src/Components/Broadcast/Broadcast.js
@@ -26,7 +26,7 @@ const Broadcast = (data) => {
       </Form>
       <h3>Customer.io settings</h3>
       <Form horizontal>
-        {renderRow('URL', <code>{webhook.url}</code>)}
+        {renderRow('URL', webhook.url)}
         {renderRow('Body', <code>{webhookBody}</code>)}
       </Form>
     </div>

--- a/client/src/Components/Broadcast/BroadcastContainer.js
+++ b/client/src/Components/Broadcast/BroadcastContainer.js
@@ -17,7 +17,7 @@ class BroadcastContainer extends React.Component {
   render() {
     return (
       <Grid>
-        <PageHeader>{this.broadcastId}</PageHeader>
+        <PageHeader><small>{this.broadcastId}</small></PageHeader>
         <HttpRequest url={this.requestUrl}>
           {res => <Broadcast broadcast={res.data} />}
         </HttpRequest>

--- a/client/src/Components/Broadcast/BroadcastContainer.js
+++ b/client/src/Components/Broadcast/BroadcastContainer.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Grid, PageHeader } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+import HttpRequest from '../HttpRequest';
+import Broadcast from './Broadcast';
+
+const helpers = require('../../helpers');
+
+class BroadcastContainer extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.broadcastId = this.props.match.params.broadcastId;
+    this.requestUrl = helpers.getBroadcastIdUrl(this.broadcastId);
+  }
+
+  render() {
+    return (
+      <Grid>
+        <PageHeader>{this.broadcastId}</PageHeader>
+        <HttpRequest url={this.requestUrl}>
+          {res => <Broadcast broadcast={res.data} />}
+        </HttpRequest>
+      </Grid>
+    );
+  }
+}
+
+BroadcastContainer.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({ broadcastId: PropTypes.string.isRequired }).isRequired,
+  }).isRequired,
+};
+
+export default BroadcastContainer;

--- a/client/src/Components/BroadcastList.js
+++ b/client/src/Components/BroadcastList.js
@@ -7,18 +7,22 @@ const helpers = require('../helpers');
 
 export default class BroadcastList extends React.Component {
   static renderRow(broadcast) {
-    console.log(broadcast);
     const broadcastId = broadcast.id;
     const campaignId = broadcast.campaignId;
+    let context = null;
+    if (broadcast.topic) {
+      context = <small>Topic: {broadcast.topic}</small>;
+    } else {
+      const url = `/campaigns/${campaignId}`;
+      context = <small>Campaign: <Link to={url}>{campaignId}</Link></small>;
+    }
 
     return (
       <tr key={broadcastId}>
         <td>
-          <Link to={`broadcasts/${broadcastId}`}>{broadcastId}</Link>
+          <small><Link to={`broadcasts/${broadcastId}`}>{broadcastId}</Link></small>
         </td>
-        <td>
-          <Link to={`campaigns/${campaignId}`}>{campaignId}</Link>
-        </td>
+        <td>{context}</td>
         <td>{broadcast.message}</td>
       </tr>
     );
@@ -40,7 +44,7 @@ export default class BroadcastList extends React.Component {
               <tbody>
                 <tr>
                   <th>ID</th>
-                  <th>Campaign</th>
+                  <th>Context</th>
                   <th>Message</th>
                 </tr>
                 {res.data.map(broadcast => BroadcastList.renderRow(broadcast))}

--- a/client/src/Components/BroadcastList.js
+++ b/client/src/Components/BroadcastList.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Grid, Image, PageHeader} from 'react-bootstrap';
+
+const BroadcastList = () => (
+  <Grid>
+    <PageHeader>Broadcasts</PageHeader>
+    <h2>Under construction</h2>
+    <Image src="http://textfiles.com/underconstruction/CaCapeCanaveralHangar2256construction.gif" />
+  </Grid>
+);
+
+
+export default BroadcastList;

--- a/client/src/Components/BroadcastList.js
+++ b/client/src/Components/BroadcastList.js
@@ -7,16 +7,17 @@ const helpers = require('../helpers');
 
 export default class BroadcastList extends React.Component {
   static renderRow(broadcast) {
+    console.log(broadcast);
     const broadcastId = broadcast.id;
     const campaignId = broadcast.campaignId;
 
     return (
       <tr key={broadcastId}>
-        <td>{broadcastId}</td>
         <td>
-          <Link to={`broadcasts/${campaignId}`}>
-            <strong>{campaignId}</strong>
-          </Link>
+          <Link to={`broadcasts/${broadcastId}`}>{broadcastId}</Link>
+        </td>
+        <td>
+          <Link to={`campaigns/${campaignId}`}>{campaignId}</Link>
         </td>
         <td>{broadcast.message}</td>
       </tr>

--- a/client/src/Components/BroadcastList.js
+++ b/client/src/Components/BroadcastList.js
@@ -1,13 +1,53 @@
 import React from 'react';
-import { Grid, Image, PageHeader} from 'react-bootstrap';
+import { Link } from 'react-router-dom';
+import { Grid, PageHeader, Table } from 'react-bootstrap';
+import HttpRequest from './HttpRequest';
 
-const BroadcastList = () => (
-  <Grid>
-    <PageHeader>Broadcasts</PageHeader>
-    <h2>Under construction</h2>
-    <Image src="http://textfiles.com/underconstruction/CaCapeCanaveralHangar2256construction.gif" />
-  </Grid>
-);
+const helpers = require('../helpers');
 
+export default class BroadcastList extends React.Component {
+  static renderRow(broadcast) {
+    const broadcastId = broadcast.id;
+    const campaignId = broadcast.campaignId;
 
-export default BroadcastList;
+    return (
+      <tr key={broadcastId}>
+        <td>{broadcastId}</td>
+        <td>
+          <Link to={`broadcasts/${campaignId}`}>
+            <strong>{campaignId}</strong>
+          </Link>
+        </td>
+        <td>{broadcast.message}</td>
+      </tr>
+    );
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.requestUrl = helpers.getBroadcastsUrl();
+  }
+
+  render() {
+    return (
+      <Grid>
+        <PageHeader>Broadcasts</PageHeader>
+        <HttpRequest url={this.requestUrl}>
+          {
+            res => (<Table striped hover>
+              <tbody>
+                <tr>
+                  <th>ID</th>
+                  <th>Campaign</th>
+                  <th>Message</th>
+                </tr>
+                {res.data.map(broadcast => BroadcastList.renderRow(broadcast))}
+              </tbody>
+            </Table>)
+          }
+        </HttpRequest>
+      </Grid>
+    );
+  }
+}

--- a/client/src/Components/Header.js
+++ b/client/src/Components/Header.js
@@ -5,6 +5,8 @@ import ConversationSearchForm from './ConversationSearchForm';
 
 class Header extends React.Component {
   render() {
+    const pathname = window.location.pathname;
+    const conversationsActive = (pathname.includes('conversations') || pathname.includes('requests'));
     return (
       <Navbar>
         <Navbar.Header>
@@ -13,7 +15,15 @@ class Header extends React.Component {
           </Navbar.Brand>
         </Navbar.Header>
         <Nav>
-          <NavItem eventKey={1} href="/campaigns">Campaigns</NavItem>
+          <NavItem active={conversationsActive} eventKey={1} href="/conversations">
+            Conversations
+          </NavItem>
+          <NavItem active={pathname.includes('campaigns')} eventKey={1} href="/campaigns">
+            Campaigns
+          </NavItem>
+          <NavItem active={pathname.includes('broadcasts')} eventKey={1} href="/broadcasts">
+            Broadcasts
+          </NavItem>
         </Nav>
         <Navbar.Form pullRight>
           <ConversationSearchForm />

--- a/client/src/Components/Main.js
+++ b/client/src/Components/Main.js
@@ -7,6 +7,8 @@ import CampaignDetail from './CampaignDetail';
 import ConversationList from './ConversationList';
 import ConversationDetail from './ConversationDetail';
 import ConversationRequest from './ConversationRequest';
+import BroadcastList from './BroadcastList';
+import BroadcastDetail from './Broadcast/BroadcastContainer';
 
 const Campaigns = () => (
   <Switch>
@@ -22,10 +24,17 @@ const Conversations = () => (
   </Switch>
 );
 
-const Requests = () => (
+const ConversationRequests = () => (
   <Switch>
     <Route exact path="/requests" component={Home} />
     <Route path="/requests/:requestId" component={ConversationRequest} />
+  </Switch>
+);
+
+const Broadcasts = () => (
+  <Switch>
+    <Route exact path="/broadcasts" component={BroadcastList} />
+    <Route path="/broadcasts/:broadcastId" component={BroadcastDetail} />
   </Switch>
 );
 
@@ -35,7 +44,8 @@ const Main = () => (
       <Route exact path="/" component={Home} />
       <Route path="/campaigns" component={Campaigns} />
       <Route path="/conversations" component={Conversations} />
-      <Route path="/requests" component={Requests} />
+      <Route path="/requests" component={ConversationRequests} />
+      <Route path="/broadcasts" component={Broadcasts} />
     </Switch>
   </main>
 );

--- a/client/src/Components/MessageList.js
+++ b/client/src/Components/MessageList.js
@@ -34,9 +34,10 @@ class MessageList extends React.Component {
     let broadcastGroupItem = null;
     const broadcastId = message.broadcastId;
     if (broadcastId) {
+      const broadcastUri = `/broadcasts/${broadcastId}`;
       broadcastGroupItem = (
         <ListGroupItem>
-          <small>Broadcast: <code>{ broadcastId }</code></small>
+          <small>Broadcast: <Link to={broadcastUri}><code>{ broadcastId }</code></Link></small>
         </ListGroupItem>
       );
     }

--- a/client/src/Components/MessageList.js
+++ b/client/src/Components/MessageList.js
@@ -116,6 +116,9 @@ class MessageList extends React.Component {
   }
 
   static renderMessageRow(message) {
+    if (!message.conversationId) {
+      return null;
+    }
     const uri = `/conversations/${message.conversationId._id}`;
     const userLink = <Link to={uri}>{message.conversationId.platformUserId}</Link>;
     const isInbound = message.direction === 'inbound';

--- a/client/src/helpers.js
+++ b/client/src/helpers.js
@@ -15,6 +15,10 @@ function apiUrl(path, query = {}) {
   return result;
 }
 
+module.exports.getBroadcastsUrl = function (query) {
+  return apiUrl('gambit-conversations/broadcasts', query);
+};
+
 module.exports.getBroadcastIdUrl = function (broadcastId) {
   return apiUrl(`gambit-conversations/broadcasts/${broadcastId}`);
 };

--- a/client/src/helpers.js
+++ b/client/src/helpers.js
@@ -15,6 +15,10 @@ function apiUrl(path, query = {}) {
   return result;
 }
 
+module.exports.getBroadcastIdUrl = function (broadcastId) {
+  return apiUrl(`gambit-conversations/broadcasts/${broadcastId}`);
+};
+
 module.exports.getCampaignIdUrl = function (campaignId) {
   return apiUrl(`gambit-campaigns/campaigns/${campaignId}`);
 };

--- a/lib/gambit-conversations.js
+++ b/lib/gambit-conversations.js
@@ -52,6 +52,10 @@ module.exports.getMessages = function (query) {
   return executeGet('messages', query);
 };
 
+module.exports.getBroadcasts = function (query) {
+  return executeGet('broadcasts', query);
+};
+
 module.exports.getBroadcastById = function (broadcastId) {
   return executeGet(`broadcast-settings/${broadcastId}`);
 };

--- a/lib/gambit-conversations.js
+++ b/lib/gambit-conversations.js
@@ -51,3 +51,7 @@ module.exports.getConversationById = function (conversationId) {
 module.exports.getMessages = function (query) {
   return executeGet('messages', query);
 };
+
+module.exports.getBroadcastById = function (broadcastId) {
+  return executeGet(`broadcast-settings/${broadcastId}`);
+};

--- a/lib/gambit-conversations.js
+++ b/lib/gambit-conversations.js
@@ -28,7 +28,7 @@ function formatResponse(res) {
  * @param {object} query
  * @return {Promise}
  */
-function executeGet(path, query = {}) {
+function executeGet(path, query = {}, format = true) {
   const url = `${config.baseUri}/${path}`;
   const auth = config.auth;
   logger.info('executeGet', { url, query });
@@ -36,7 +36,10 @@ function executeGet(path, query = {}) {
   return superagent.get(url)
     .query(query)
     .auth(auth.name, auth.pass)
-    .then(res => formatResponse(res))
+    .then((res) => {
+      if (format) return formatResponse(res);
+      return res.body;
+    })
     .catch(err => err);
 }
 
@@ -57,5 +60,5 @@ module.exports.getBroadcasts = function (query) {
 };
 
 module.exports.getBroadcastById = function (broadcastId) {
-  return executeGet(`broadcast-settings/${broadcastId}`);
+  return executeGet(`broadcasts/${broadcastId}`, {}, false);
 };

--- a/routes/gambit-conversations.js
+++ b/routes/gambit-conversations.js
@@ -55,4 +55,10 @@ router.get('/messages', (req, res) => {
     .catch(err => helpers.sendResponseForError(res, err));
 });
 
+router.get('/broadcasts/:id', (req, res) => {
+  conversations.getBroadcastById(req.params.id)
+    .then(apiRes => res.send(apiRes))
+    .catch(err => helpers.sendResponseForError(res, err));
+});
+
 module.exports = router;

--- a/routes/gambit-conversations.js
+++ b/routes/gambit-conversations.js
@@ -55,6 +55,12 @@ router.get('/messages', (req, res) => {
     .catch(err => helpers.sendResponseForError(res, err));
 });
 
+router.get('/broadcasts', (req, res) => {
+  conversations.getBroadcasts(req.query)
+    .then(apiRes => res.send(apiRes))
+    .catch(err => helpers.sendResponseForError(res, err));
+});
+
 router.get('/broadcasts/:id', (req, res) => {
   conversations.getBroadcastById(req.params.id)
     .then(apiRes => res.send(apiRes))


### PR DESCRIPTION
Starts on displaying data from the new [Conversations Broadcasts endpoint](https://github.com/DoSomething/gambit-conversations/pull/244).

* Adds a `/broadcasts` list view of all Conversations Broadcasts
* Adds a `/broadcasts/:id` view of a Broadcast, displaying total of inbound and outbound messages for the Broadcast, as well as the values to [use in the Customer.io setup](https://github.com/DoSomething/gambit-conversations/wiki/Broadcasts#2-get-broadcast-settings).

Will deploy to staging to confirm works as expected (https://github.com/DoSomething/gambit-conversations/pull/244 has been deployed to Conversations Staging).