### PR TITLE
Broadcast replies

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "eslint-config-react-app": "^1.0.5",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-react": "^7.1.0",
+    "lodash": "^4.17.4",
     "moment": "^2.18.1",
     "prop-types": "^15.6.0",
     "query-string": "^5.0.0",

--- a/client/src/Components/Broadcast/Broadcast.js
+++ b/client/src/Components/Broadcast/Broadcast.js
@@ -24,13 +24,13 @@ function renderRow(label, data) {
  * @param {string} label
  * @param {number} count
  */
-function renderMacroCount(macroName, label, count, total) {
+function MacroStats({ name, label, count, total }) {
   let data = count;
   if (!count) {
     data = 0;
   }
   const rate = percent(data, total);
-  const url = `${window.location.pathname}/${macroName}`;
+  const url = `${window.location.pathname}/${name}`;
 
   return (
     <tr>
@@ -40,6 +40,13 @@ function renderMacroCount(macroName, label, count, total) {
     </tr>
   );
 }
+
+MacroStats.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.shape.isRequired,
+  count: PropTypes.number.isRequired,
+  total: PropTypes.number.isRequired,
+};
 
 /**
  * @param {object} data
@@ -53,10 +60,30 @@ function renderMacros(macros, total) {
   return (
     <Table striped>
       <tbody>
-        {renderMacroCount('confirmedCampaign', 'Yes', macros.confirmedCampaign, total)}
-        {renderMacroCount('declinedCampaign', 'No', macros.declinedCampaign, total)}
-        {renderMacroCount('subscriptionStatusStop', 'Stop', macros.subscriptionStatusStop, total)}
-        {renderMacroCount('other', 'Other', otherCount, total)}
+        <MacroStats
+          name="confirmedCampaign"
+          label="Yes"
+          count={macros.confirmedCampaign}
+          total={total}
+        />
+        <MacroStats
+          name="declinedCampaign"
+          label="No"
+          count={macros.declinedCampaign}
+          total={total}
+        />
+        <MacroStats
+          name="subscriptionStatusStop"
+          label="Stop"
+          count={macros.subscriptionStatusStop}
+          total={total}
+        />
+        <MacroStats
+          name="other"
+          label="Other"
+          count={otherCount}
+          total={total}
+        />
       </tbody>
     </Table>
   );

--- a/client/src/Components/Broadcast/Broadcast.js
+++ b/client/src/Components/Broadcast/Broadcast.js
@@ -33,7 +33,7 @@ function renderMacroCount(label, count, total) {
   return (
     <tr>
       <td>{label}</td>
-      <td>{data}</td>
+      <td>{data.toLocaleString()}</td>
       <td>{rate}</td>
     </tr>
   );

--- a/client/src/Components/Broadcast/BroadcastContainer.js
+++ b/client/src/Components/Broadcast/BroadcastContainer.js
@@ -16,7 +16,7 @@ class BroadcastContainer extends React.Component {
   render() {
     return (
       <HttpRequest url={this.requestUrl}>
-        {res => <Broadcast broadcast={res.data} />}
+        {res => <Broadcast broadcast={res.data} macro={this.macro} />}
       </HttpRequest>
     );
   }

--- a/client/src/Components/Broadcast/BroadcastReplyList.js
+++ b/client/src/Components/Broadcast/BroadcastReplyList.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Breadcrumb, Grid } from 'react-bootstrap';
+import MessageList from '../MessageList/MessageListContainer';
+
+function formatMacro(macro) {
+  if (macro === 'confirmedCampaign') {
+    return 'Yes';
+  }
+  if (macro === 'declinedCampaign') {
+    return 'No';
+  }
+  if (macro === 'subscriptionStatusStop') {
+    return 'Unsubscribe';
+  }
+  return 'Other';
+}
+
+class BroadcastReplyList extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.broadcastId = this.props.match.params.broadcastId;
+    this.macro = this.props.match.params.macro;
+  }
+
+  render() {
+    const url = `/broadcasts/${this.broadcastId}`;
+    return (
+      <Grid>
+        <Breadcrumb>
+          <Breadcrumb.Item href="/broadcasts">
+            Broadcasts
+          </Breadcrumb.Item>
+          <Breadcrumb.Item href={url}>
+            {this.broadcastId}
+          </Breadcrumb.Item>
+          <Breadcrumb.Item active>
+            {formatMacro(this.macro)}
+          </Breadcrumb.Item>
+        </Breadcrumb>
+        <MessageList broadcastId={this.broadcastId} macro={this.macro} table />
+      </Grid>
+    );
+  }
+}
+
+BroadcastReplyList.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      broadcastId: PropTypes.string.isRequired,
+      macro: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+};
+
+export default BroadcastReplyList;

--- a/client/src/Components/Broadcast/BroadcastReplyList.js
+++ b/client/src/Components/Broadcast/BroadcastReplyList.js
@@ -3,29 +3,23 @@ import PropTypes from 'prop-types';
 import { Breadcrumb, Grid } from 'react-bootstrap';
 import MessageList from '../MessageList/MessageListContainer';
 
-function formatMacro(macro) {
-  if (macro === 'confirmedCampaign') {
-    return 'Yes';
-  }
-  if (macro === 'declinedCampaign') {
-    return 'No';
-  }
-  if (macro === 'subscriptionStatusStop') {
-    return 'Unsubscribe';
-  }
-  return 'Other';
+const lodash = require('lodash');
+
+function formatMacro(macroName) {
+  const macroLabels = {
+    confirmedCampaign: 'Yes',
+    declinedCampaign: 'No',
+    subscriptionStatusStop: 'Unsubscribe',
+  };
+  return lodash.get(macroLabels, macroName, 'Other');
 }
 
 class BroadcastReplyList extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.broadcastId = this.props.match.params.broadcastId;
-    this.macro = this.props.match.params.macro;
-  }
-
   render() {
-    const url = `/broadcasts/${this.broadcastId}`;
+    const broadcastId = this.props.match.params.broadcastId;
+    const macro = this.props.match.params.macro;
+    const url = `/broadcasts/${broadcastId}`;
+
     return (
       <Grid>
         <Breadcrumb>
@@ -33,13 +27,13 @@ class BroadcastReplyList extends React.Component {
             Broadcasts
           </Breadcrumb.Item>
           <Breadcrumb.Item href={url}>
-            {this.broadcastId}
+            {broadcastId}
           </Breadcrumb.Item>
           <Breadcrumb.Item active>
-            {formatMacro(this.macro)}
+            {formatMacro(macro)}
           </Breadcrumb.Item>
         </Breadcrumb>
-        <MessageList broadcastId={this.broadcastId} macro={this.macro} table />
+        <MessageList broadcastId={broadcastId} macro={macro} table />
       </Grid>
     );
   }

--- a/client/src/Components/Main.js
+++ b/client/src/Components/Main.js
@@ -9,6 +9,7 @@ import ConversationDetail from './ConversationDetail';
 import ConversationRequest from './ConversationRequest';
 import BroadcastList from './BroadcastList/BroadcastListContainer';
 import BroadcastDetail from './Broadcast/BroadcastContainer';
+import BroadcastReplyList from './Broadcast/BroadcastReplyList';
 
 const Campaigns = () => (
   <Switch>
@@ -34,6 +35,7 @@ const ConversationRequests = () => (
 const Broadcasts = () => (
   <Switch>
     <Route exact path="/broadcasts" component={BroadcastList} />
+    <Route path="/broadcasts/:broadcastId/:macro" component={BroadcastReplyList} />
     <Route path="/broadcasts/:broadcastId" component={BroadcastDetail} />
   </Switch>
 );

--- a/client/src/Components/MessageList/MessageList.js
+++ b/client/src/Components/MessageList/MessageList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid, Pager } from 'react-bootstrap';
+import { Pager, Table } from 'react-bootstrap';
 import MessageListItem from './MessageListItem';
 
 function renderPager(totalResultCount, skipCount, pageCount, pageSize) {
@@ -37,13 +37,18 @@ function renderPager(totalResultCount, skipCount, pageCount, pageSize) {
 }
 
 const MessageList = (props) => {
+  if (!props.data) {
+    return <div>No results found.</div>;
+  }
   const pager = renderPager(props.totalCount, props.skipCount, props.data.length, props.pageSize);
+  let data = props.data.map(message => <MessageListItem table={props.table} message={message} />);
+  if (props.table) {
+    data = <Table><tbody>{data}</tbody></Table>;
+  }
   return (
     <div>
       { pager }
-      <Grid>
-        { props.data.map(message => <MessageListItem message={message} />) }
-      </Grid>
+      { data }
       { props.totalCount > 10 ? pager : null }
     </div>
   );

--- a/client/src/Components/MessageList/MessageList.js
+++ b/client/src/Components/MessageList/MessageList.js
@@ -59,6 +59,7 @@ MessageList.propTypes = {
   skipCount: PropTypes.number.isRequired,
   data: PropTypes.arrayOf(PropTypes.shape).isRequired,
   pageSize: PropTypes.number.isRequired,
+  table: PropTypes.bool.isRequired,
 };
 
 export default MessageList;

--- a/client/src/Components/MessageList/MessageListContainer.js
+++ b/client/src/Components/MessageList/MessageListContainer.js
@@ -25,6 +25,14 @@ class MessageListContainer extends React.Component {
       apiQuery.query = `{"conversationId":"${this.props.conversationId}"}`;
     } else if (this.props.requestId) {
       apiQuery.query = `{"metadata.requestId":"${this.props.requestId}"}`;
+    } else if (this.props.broadcastId) {
+      let query;
+      if (this.props.macro === 'other') {
+        query = `{"broadcastId":"${this.props.broadcastId}","direction":"inbound","macro":{"$nin":["confirmedCampaign","declinedCampaign","subscriptionStatusStop"]}}`;
+      } else {
+        query = `{"broadcastId":"${this.props.broadcastId}","direction":"inbound","macro":"${this.props.macro}"}`;
+      }
+      apiQuery.query = query;
     }
 
     // Check for skip query string parameter.
@@ -43,14 +51,21 @@ class MessageListContainer extends React.Component {
     return (
       <HttpRequest url={this.requestUrl}>
         {
-          res => (
-            <MessageList
-              totalCount={res.pagination.total}
-              data={res.data}
-              skipCount={this.skipCount}
-              pageSize={pageSize}
-            />
-          )
+          (res) => {
+            let total = 0;
+            if (res.pagination && res.pagination.total) {
+              total = res.pagination.total;
+            }
+            return (
+              <MessageList
+                totalCount={total}
+                data={res.data}
+                skipCount={this.skipCount}
+                pageSize={pageSize}
+                table={this.props.table}
+              />
+            );
+          }
         }
       </HttpRequest>
     );

--- a/client/src/Components/MessageList/MessageListContainer.js
+++ b/client/src/Components/MessageList/MessageListContainer.js
@@ -73,15 +73,21 @@ class MessageListContainer extends React.Component {
 }
 
 MessageListContainer.propTypes = {
+  broadcastId: PropTypes.string,
   campaignId: PropTypes.string,
   conversationId: PropTypes.string,
+  macro: PropTypes.string,
   requestId: PropTypes.string,
+  table: PropTypes.bool,
 };
 
 MessageListContainer.defaultProps = {
+  broadcastId: null,
   campaignId: null,
   conversationId: null,
+  macro: null,
   requestId: null,
+  table: false,
 };
 
 export default MessageListContainer;

--- a/client/src/Components/MessageList/MessageListItem.js
+++ b/client/src/Components/MessageList/MessageListItem.js
@@ -109,6 +109,7 @@ function renderContent(message) {
   );
 }
 
+
 const MessageListItem = (props) => {
   const message = props.message;
   if (!message.conversationId) {
@@ -118,6 +119,16 @@ const MessageListItem = (props) => {
   const userLink = <Link to={uri}>{message.conversationId.platformUserId}</Link>;
   const isInbound = message.direction === 'inbound';
   const offset = isInbound ? 0 : 1;
+
+  if (props.table) {
+    return (
+      <tr key={message._id}>
+        <td width="15%"><small>{renderDate(message)}</small></td>
+        <td width="15%">{userLink}</td>
+        <td>{message.text}</td>
+      </tr>
+    ); 
+  }
 
   return (
     <Row key={message._id}>
@@ -132,6 +143,7 @@ const MessageListItem = (props) => {
 
 MessageListItem.propTypes = {
   message: PropTypes.shape.isRequired,
+  table: PropTypes.bool,
 };
 
 export default MessageListItem;

--- a/client/src/Components/MessageList/MessageListItem.js
+++ b/client/src/Components/MessageList/MessageListItem.js
@@ -127,7 +127,7 @@ const MessageListItem = (props) => {
         <td width="15%">{userLink}</td>
         <td>{message.text}</td>
       </tr>
-    ); 
+    );
   }
 
   return (
@@ -143,7 +143,7 @@ const MessageListItem = (props) => {
 
 MessageListItem.propTypes = {
   message: PropTypes.shape.isRequired,
-  table: PropTypes.bool,
+  table: PropTypes.bool.isRequired,
 };
 
 export default MessageListItem;


### PR DESCRIPTION
Adds lists of inbound messages replying to a Broadcast, grouped by Yes, No, Unsubscribe, and Other a la indices added in https://github.com/DoSomething/gambit-conversations/pull/258.

* Calls `MessageList` with a  new `table` prop. When set, renders the list as a Bootstrap Table.

Will deploy this branch to confirm 👍 and link to examples.