### PR TITLE
Removes Mobile Commons URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,11 +12,7 @@ DS_NORTHSTAR_API_KEY=secret
 DS_ROGUE_BASEURI=https://rogue-thor.dosomething.org
 DS_ROGUE_API_KEY=secret
 
-
-## PROFILE LINKS
-
 DS_AURORA_PROFILE_BASEURI=https://aurora-thor.dosomething.org/users
-MOBILECOMMONS_PROFILE_BASEURI=https://secure.mobilecommons.com/profiles
 
 ## Client
 

--- a/client/src/Components/ConversationDetail.js
+++ b/client/src/Components/ConversationDetail.js
@@ -99,12 +99,6 @@ class ConversationDetail extends React.Component {
     if (user.source) {
       registrationSource = `via ${helpers.formatSource(user.source)}`;
     }
-    const auroraLink = <a href={user.links.aurora}>Aurora</a>;
-    const rogueLink = <a href={user.links.rogue}>Rogue</a>;
-    let mobileCommonsLink = null;
-    if (user.links.mobilecommons) {
-      mobileCommonsLink = <span> | <a href={user.links.mobilecommons}>Mobile Commons</a></span>;
-    }
 
     return (
       <Panel>
@@ -127,9 +121,6 @@ class ConversationDetail extends React.Component {
         <Row>
           <Col sm={6}>
             <strong>Joined:</strong> {registrationDate} {registrationSource}
-          </Col>
-          <Col sm={6}>
-            <strong>Profiles:</strong> {auroraLink}  | {rogueLink} {mobileCommonsLink}
           </Col>
         </Row>
       </Panel>

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -45,26 +45,6 @@ module.exports.getAuroraUrlForUserId = function (userId) {
 };
 
 /**
- * @param {string} userId
- * @return {string}
- */
-module.exports.getMobileCommonsUrlForMobileCommonsId = function (mobileCommonsId) {
-  const baseUri = process.env.MOBILECOMMONS_PROFILE_BASEURI;
-  const result = `${baseUri}/${mobileCommonsId}`;
-  return result;
-};
-
-/**
- * @param {string} userId
- * @return {string}
- */
-module.exports.getRogueUrlForUserId = function (userId) {
-  const baseUri = process.env.DS_ROGUE_BASEURI;
-  const result = `${baseUri}/users/${userId}`;
-  return result;
-};
-
-/**
  * @param {string} signupId
  * @return {string}
  */

--- a/routes/gambit-conversations.js
+++ b/routes/gambit-conversations.js
@@ -31,12 +31,7 @@ router.get('/conversations/:id', (req, res) => {
       const userId = user.id;
       req.data.user.links = {
         aurora: helpers.getAuroraUrlForUserId(userId),
-        rogue: helpers.getRogueUrlForUserId(userId),
       };
-      if (user.mobilecommons_id) {
-        const url = helpers.getMobileCommonsUrlForMobileCommonsId(user.mobilecommons_id);
-        req.data.user.links.mobilecommons = url;
-      }
       return rogue.getSignupsForUserId(userId);
     })
     .then((apiRes) => {


### PR DESCRIPTION
Removes the Links section on the Profile:
* Removes deprecated Mobile Commons URL
* Removes Rogue User URL - this data is displayed on the Signups tab in #29 

Note - the User ID field still links out to the User Aurora profile.