### PR TITLE
Hide Yes/No stats for Topic broadcasts

### DIFF
--- a/client/src/Components/Broadcast/Broadcast.js
+++ b/client/src/Components/Broadcast/Broadcast.js
@@ -50,32 +50,48 @@ MacroStats.propTypes = {
 };
 
 /**
- * @param {object} data
+ * @param {object} broadcast
  */
-function renderMacros(macros, total) {
+function renderMacros(broadcast) {
+  const stats = broadcast.stats;
+  const macros = stats.inbound.macros;
   if (!macros) {
     return null;
   }
-  const yesCount = macros.confirmedCampaign ? macros.confirmedCampaign : 0;
-  const noCount = macros.declinedCampaign ? macros.declinedCampaign : 0;
+  const total = stats.inbound.total;
   const stopCount = macros.subscriptionStatusStop ? macros.subscriptionStatusStop : 0;
-  const sum = yesCount + noCount + stopCount;
-  const otherCount = total - sum;
+  let otherCount = total - stopCount;
+  let yesStats = null;
+  let noStats = null;
+  if (!broadcast.topic) {
+    const yesCount = macros.confirmedCampaign ? macros.confirmedCampaign : 0;
+    const noCount = macros.declinedCampaign ? macros.declinedCampaign : 0;
+    const sum = yesCount + noCount + stopCount;
+    otherCount = total - sum;
+
+    yesStats = (
+      <MacroStats
+        name="confirmedCampaign"
+        label="Yes"
+        count={yesCount}
+        total={total}
+      />
+    );
+    noStats = (
+      <MacroStats
+        name="declinedCampaign"
+        label="No"
+        count={noCount}
+        total={total}
+      />
+    );
+  }
+
   return (
     <Table striped>
       <tbody>
-        <MacroStats
-          name="confirmedCampaign"
-          label="Yes"
-          count={yesCount}
-          total={total}
-        />
-        <MacroStats
-          name="declinedCampaign"
-          label="No"
-          count={noCount}
-          total={total}
-        />
+        {yesStats}
+        {noStats}
         <MacroStats
           name="subscriptionStatusStop"
           label="Stop"
@@ -117,7 +133,7 @@ function renderStats(broadcast) {
   return (
     <div>
       {renderStatsHeader(stats)}
-      {total > 0 ? renderMacros(stats.inbound.macros, total) : null}
+      {total > 0 ? renderMacros(broadcast) : null}
     </div>
   );
 }

--- a/client/src/Components/Broadcast/Broadcast.js
+++ b/client/src/Components/Broadcast/Broadcast.js
@@ -55,7 +55,10 @@ function renderMacros(macros, total) {
   if (!macros) {
     return null;
   }
-  const sum = macros.confirmedCampaign + macros.declinedCampaign + macros.subscriptionStatusStop;
+  const yesCount = macros.confirmedCampaign ? macros.confirmedCampaign : 0;
+  const noCount = macros.declinedCampaign ? macros.declinedCampaign : 0;
+  const stopCount = macros.subscriptionStatusStop ? macros.subscriptionStatusStop : 0;
+  const sum = yesCount + noCount + stopCount;
   const otherCount = total - sum;
   return (
     <Table striped>
@@ -63,19 +66,19 @@ function renderMacros(macros, total) {
         <MacroStats
           name="confirmedCampaign"
           label="Yes"
-          count={macros.confirmedCampaign}
+          count={yesCount}
           total={total}
         />
         <MacroStats
           name="declinedCampaign"
           label="No"
-          count={macros.declinedCampaign}
+          count={noCount}
           total={total}
         />
         <MacroStats
           name="subscriptionStatusStop"
           label="Stop"
-          count={macros.subscriptionStatusStop}
+          count={stopCount}
           total={total}
         />
         <MacroStats

--- a/client/src/Components/Broadcast/Broadcast.js
+++ b/client/src/Components/Broadcast/Broadcast.js
@@ -26,11 +26,12 @@ function renderRow(label, data) {
  */
 function MacroStats({ name, label, count, total }) {
   let data = count;
+  let url = `${window.location.pathname}/${name}`;
   if (!count) {
     data = 0;
+    url = '#';
   }
   const rate = percent(data, total);
-  const url = `${window.location.pathname}/${name}`;
 
   return (
     <tr>


### PR DESCRIPTION
Rivescript topic broadcasts are showing invalid Other counts because the `confirmedCampaign` and `declinedCampaign` stats will never be set -- the Conversation topic is set to the Rivescript topic, where yes and no messages won't trigger the `confirmedCampaign` and `declinedCampaign` macros as they do in the `'campaign'` Rivescript topic.

This PR hides the Yes/No stats for Topic broadcasts and fixes the number of Other messages (in this case, only other than Stop macros).