### PR TITLE
Check for Conversation.userId

### DIFF
--- a/client/src/Components/ConversationDetail.js
+++ b/client/src/Components/ConversationDetail.js
@@ -131,7 +131,12 @@ class ConversationDetail extends React.Component {
             <strong>Address:</strong> {address} {addressSource}
           </Col>
           <Col sm={6}>
-            <strong>Joined:</strong> {registrationDate} {registrationSource}
+            <strong>Links:</strong> <a href={user.links.aurora}>Aurora</a>
+          </Col>
+        </Row>
+        <Row>
+          <Col sm={12}>
+            <strong>Member Since:</strong> {registrationDate} {registrationSource}
           </Col>
         </Row>
       </Panel>

--- a/client/src/Components/ConversationDetail.js
+++ b/client/src/Components/ConversationDetail.js
@@ -180,7 +180,7 @@ class ConversationDetail extends React.Component {
     return (
       <Grid>
         <PageHeader>
-          { conversation.platformUserId } {conversation.user.id} {platformLabel}
+          {conversation.user.id} {platformLabel} {pausedLabel}
         </PageHeader>
         {conversation.user ? ConversationDetail.renderUser(conversation.user) : ''}
         {this.renderNav(conversation)}

--- a/client/src/Components/ConversationDetail.js
+++ b/client/src/Components/ConversationDetail.js
@@ -112,10 +112,10 @@ class ConversationDetail extends React.Component {
       <Panel>
         <Row>
           <Col sm={6}>
-            <strong>User:</strong> <a href={user.links.aurora}><code>{user.id}</code></a>
+            <strong>Mobile:</strong> {user.mobile}
           </Col>
           <Col sm={6}>
-            <strong>SMS status:</strong> {user.sms_status}
+            <strong>SMS Status:</strong> {user.sms_status}
           </Col>
         </Row>
         <Row>
@@ -123,7 +123,7 @@ class ConversationDetail extends React.Component {
             <strong>Email:</strong> {user.email}
           </Col>
           <Col sm={6}>
-            <strong>Last inbound message:</strong> {lastMessagedDate}
+            <strong>SMS Last Inbound:</strong> {lastMessagedDate}
           </Col>
         </Row>
         <Row>
@@ -180,7 +180,7 @@ class ConversationDetail extends React.Component {
     return (
       <Grid>
         <PageHeader>
-          { conversation.platformUserId } {pausedLabel} {platformLabel}
+          { conversation.platformUserId } {conversation.user.id} {platformLabel}
         </PageHeader>
         {conversation.user ? ConversationDetail.renderUser(conversation.user) : ''}
         {this.renderNav(conversation)}

--- a/client/src/Components/ConversationList.js
+++ b/client/src/Components/ConversationList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Grid, Label, PageHeader, Table } from 'react-bootstrap';
+import { Grid, Label, Table } from 'react-bootstrap';
 import Moment from 'react-moment';
 import HttpRequest from './HttpRequest';
 
@@ -10,7 +10,7 @@ const helpers = require('../helpers');
 
 export default class ConversationList extends React.Component {
   static renderRow(conversation) {
-    const user = conversation.userId || conversation.platformUserId;
+    const identifier = helpers.getUserIdentifierForConversation(conversation);
     let platformLabel = '';
     if (conversation.platform !== 'sms') {
       platformLabel = <Label>{conversation.platform}</Label>;
@@ -18,7 +18,7 @@ export default class ConversationList extends React.Component {
     return (
       <tr key={conversation._id}>
         <td><Moment format={config.dateFormat}>{conversation.updatedAt}</Moment></td>
-        <td><Link to={`conversations/${conversation._id}`}>{user}</Link> {platformLabel}</td>
+        <td><Link to={`conversations/${conversation._id}`}>{identifier}</Link> {platformLabel}</td>
         <td>{conversation.campaignId}</td>
         <td>{conversation.topic}</td>
       </tr>
@@ -43,7 +43,6 @@ export default class ConversationList extends React.Component {
   render() {
     return (
       <Grid>
-        <PageHeader>Conversations</PageHeader>
         <HttpRequest url={this.requestUrl}>
           {
             res => (

--- a/client/src/Components/ConversationList.js
+++ b/client/src/Components/ConversationList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Grid, PageHeader, Table } from 'react-bootstrap';
+import { Grid, Label, PageHeader, Table } from 'react-bootstrap';
 import Moment from 'react-moment';
 import HttpRequest from './HttpRequest';
 
@@ -10,10 +10,15 @@ const helpers = require('../helpers');
 
 export default class ConversationList extends React.Component {
   static renderRow(conversation) {
+    const identifier = conversation.userId || conversation.platformUserId;
+    let platformLabel = '';
+    if (conversation.platform !== 'sms') {
+      platformLabel = <Label>{conversation.platform}</Label>;
+    }
     return (
       <tr key={conversation._id}>
         <td><Moment format={config.dateFormat}>{conversation.updatedAt}</Moment></td>
-        <td><Link to={`conversations/${conversation._id}`}>{conversation.platformUserId}</Link></td>
+        <td><Link to={`conversations/${conversation._id}`}>{identifier}</Link> {platformLabel}</td>
         <td>{conversation.campaignId}</td>
         <td>{conversation.topic}</td>
       </tr>
@@ -46,7 +51,7 @@ export default class ConversationList extends React.Component {
                 <tbody>
                   <tr>
                     <th>Last Updated</th>
-                    <th>Platform User ID</th>
+                    <th>User</th>
                     <th>Current Campaign</th>
                     <th>Topic</th>
                   </tr>

--- a/client/src/Components/ConversationList.js
+++ b/client/src/Components/ConversationList.js
@@ -10,7 +10,7 @@ const helpers = require('../helpers');
 
 export default class ConversationList extends React.Component {
   static renderRow(conversation) {
-    const identifier = conversation.userId || conversation.platformUserId;
+    const user = conversation.userId || conversation.platformUserId;
     let platformLabel = '';
     if (conversation.platform !== 'sms') {
       platformLabel = <Label>{conversation.platform}</Label>;
@@ -18,7 +18,7 @@ export default class ConversationList extends React.Component {
     return (
       <tr key={conversation._id}>
         <td><Moment format={config.dateFormat}>{conversation.updatedAt}</Moment></td>
-        <td><Link to={`conversations/${conversation._id}`}>{identifier}</Link> {platformLabel}</td>
+        <td><Link to={`conversations/${conversation._id}`}>{user}</Link> {platformLabel}</td>
         <td>{conversation.campaignId}</td>
         <td>{conversation.topic}</td>
       </tr>

--- a/client/src/Components/Header.js
+++ b/client/src/Components/Header.js
@@ -16,7 +16,7 @@ class Header extends React.Component {
         </Navbar.Header>
         <Nav>
           <NavItem active={conversationsActive} eventKey={1} href="/conversations">
-            Conversations
+            Users
           </NavItem>
           <NavItem active={pathname.includes('campaigns')} eventKey={1} href="/campaigns">
             Campaigns

--- a/client/src/Components/MessageList/MessageListItem.js
+++ b/client/src/Components/MessageList/MessageListItem.js
@@ -116,7 +116,7 @@ const MessageListItem = (props) => {
     return null;
   }
   const uri = `/conversations/${message.conversationId._id}`;
-  const userLink = <Link to={uri}>{message.conversationId.platformUserId}</Link>;
+  const userLink = <Link to={uri}>{message.conversationId._id}</Link>;
   const isInbound = message.direction === 'inbound';
   const offset = isInbound ? 0 : 1;
 
@@ -133,7 +133,7 @@ const MessageListItem = (props) => {
   return (
     <Row key={message._id}>
       <Col md={2} mdOffset={2}>
-        <div>{ isInbound ? 'From' : 'To' } <strong>{userLink}</strong></div>
+        <div><small><strong>{userLink}</strong></small></div>
         <small>{ renderDate(message) }</small>
       </Col>
       <Col md={4} mdOffset={offset}>{ renderContent(message) }</Col>

--- a/client/src/Components/MessageList/MessageListItem.js
+++ b/client/src/Components/MessageList/MessageListItem.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { Col, Row, ListGroup, ListGroupItem, Image } from 'react-bootstrap';
 import Moment from 'react-moment';
 
+const helpers = require('../../helpers');
 const config = require('../../config');
 
 function renderDate(message) {
@@ -115,8 +116,9 @@ const MessageListItem = (props) => {
   if (!message.conversationId) {
     return null;
   }
+  const identifier = helpers.getUserIdentifierForConversation(message.conversationId);
   const uri = `/conversations/${message.conversationId._id}`;
-  const userLink = <Link to={uri}>{message.conversationId._id}</Link>;
+  const userLink = <Link to={uri}>{identifier}</Link>;
   const isInbound = message.direction === 'inbound';
   const offset = isInbound ? 0 : 1;
 

--- a/client/src/helpers.js
+++ b/client/src/helpers.js
@@ -43,6 +43,13 @@ module.exports.getMessagesUrl = function (query) {
   return apiUrl('gambit-conversations/messages', query);
 };
 
+module.exports.getUserIdentifierForConversation = function (conversation) {
+  if (conversation.userId) {
+    return conversation.userId;
+  }
+  return conversation.platformUserId;
+};
+
 /**
  * @param {string} input
  * @return {string}

--- a/routes/gambit-conversations.js
+++ b/routes/gambit-conversations.js
@@ -19,10 +19,13 @@ router.get('/conversations/:id', (req, res) => {
   conversations.getConversationById(req.params.id)
     .then((apiRes) => {
       req.data = apiRes.data;
+      if (req.data.userId) {
+        return northstar.getUserById(req.data.userId);
+      }
       if (req.data.platform === 'sms') {
         return northstar.getUserByMobile(req.data.platformUserId);
       }
-      return northstar.getUserById(req.data.platformUserId);
+      return null;
     })
     .then((user) => {
       logger.debug('northstar response', { user });

--- a/routes/gambit-conversations.js
+++ b/routes/gambit-conversations.js
@@ -19,13 +19,14 @@ router.get('/conversations/:id', (req, res) => {
   conversations.getConversationById(req.params.id)
     .then((apiRes) => {
       req.data = apiRes.data;
-      if (req.data.userId) {
-        return northstar.getUserById(req.data.userId);
+      // This check is needed until all Gambit Conversations are backfilled with userId's.
+      if (!req.data.userId) {
+        if (req.data.platform === 'sms') {
+          return northstar.getUserByMobile(req.data.platformUserId);
+        }
+        return northstar.getUserById(req.data.platformUserId);
       }
-      if (req.data.platform === 'sms') {
-        return northstar.getUserByMobile(req.data.platformUserId);
-      }
-      return null;
+      return northstar.getUserById(req.data.userId);
     })
     .then((user) => {
       logger.debug('northstar response', { user });


### PR DESCRIPTION
Fetches User by `Conversation.userId` property if it exists, defaulting to fetch by mobile on the `platformUserId` otherwise. I'm working on adding a `userId` property to a Gambit Conversation and using this branch to test that things are working are expected (for new Conversations with a `userId`, and existing ones that don't have it yet)

* Also supports short-lived storing the User ID as `platformUserId` for Gambit Slack conversations over the past sprint or so.

* Displays the Northstar User ID instead of mobile number in the Conversation Detail `PageHeader`, renames the Conversations tab to Users to better indicate the PageHeader is the uid


TODO:
* Refactor `ConversationDetail` at `/conversation/:conversationId` to `UserDetail` at `/users/:userId`. All production users will only have one Conversation: SMS. Staffers may have two: SMS and Gambit Slack -- these should be separate tabs on the User view.

cc @rapala61 