### PR TITLE
Fixes URL bug from #44

### DIFF
--- a/client/src/Components/ConversationSearchForm.js
+++ b/client/src/Components/ConversationSearchForm.js
@@ -18,7 +18,7 @@ export default class SearchForm extends React.Component {
     event.preventDefault();
     const location = window.location;
     const url = [location.protocol, '//', location.host].join('');
-    const destination = `${url}/conversations?platformUserId=${this.state.value}`;
+    const destination = `${url}/users?platformUserId=${this.state.value}`;
     window.location.href = destination;
   }
 


### PR DESCRIPTION
Changed the `/conversations` URL to `/users` in #44 but forgot to update the search form redirect.