### PR TITLE
Adds helpers.getHardcodedTopics

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gambit-admin-client",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11087,7 +11087,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }

--- a/client/package.json
+++ b/client/package.json
@@ -2,6 +2,10 @@
   "name": "gambit-admin-client",
   "version": "1.8.0",
   "private": true,
+  "engines": {
+    "node": "8.11.1",
+    "npm": "5.7.1"
+  },
   "proxy": "http://localhost:3000/",
   "dependencies": {
     "@dosomething/eslint-config": "^3.1.2",

--- a/client/src/Components/MessageList/MessageListItem.js
+++ b/client/src/Components/MessageList/MessageListItem.js
@@ -66,12 +66,10 @@ function renderContent(message) {
     );
   }
 
-  // TODO: Add all hardcoded topics and set via config.
-  const hardcodedTopics = ['random', 'support', 'survey_response', 'support'];
   let topicValue = message.topic;
-  if (!hardcodedTopics.includes(message.topic)) {
+  if (!helpers.getHardcodedTopics().includes(topicValue)) {
     const topicUri = `/topics/${topicValue}`;
-    topicValue = <Link to={topicUri}><code>{topicValue}</code></Link>;
+    topicValue = <Link to={topicUri}>{topicValue}</Link>;
   }
   const topicGroupItem = (
     <ListGroupItem>

--- a/client/src/helpers.js
+++ b/client/src/helpers.js
@@ -1,6 +1,23 @@
 const querystring = require('querystring');
 const config = require('./config');
 
+/**
+ * @return {Array}
+ */
+function getHardcodedTopics() {
+  return [
+    'askSubscriptionStatus',
+    'campaign',
+    'flsa',
+    'random',
+    'support',
+    'survey_response',
+    'tmi_completed',
+    'tmi_level1',
+    'unsubscribed',
+  ];
+}
+
 module.exports = {
   /**
    * Returns localhost API url for given path and query object.
@@ -32,6 +49,7 @@ module.exports = {
   getConversationsPath: function getConversationsPath() {
     return 'conversations';
   },
+  getHardcodedTopics,
   getMessagesPath: function getMessagesPath() {
     return 'messages';
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gambit-admin-server",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Adds helper to list hardcoded Rivescript topics that shouldn't link to a `TopicDetail` view, as our Content API topics should. Also fixes #40 