### PR TITLE
Display topic names + campaign topic list [pr]

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gambit-admin-client",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1812,9 +1812,9 @@
       }
     },
     "classnames": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
-      "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "clean-css": {
       "version": "4.1.9",
@@ -2726,9 +2726,9 @@
       }
     },
     "dom-helpers": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz",
-      "integrity": "sha1-MgPgf+0he9H0JLAZc1WC/Deyglo="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
+      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
     },
     "dom-serializer": {
       "version": "0.1.0",
@@ -6291,9 +6291,9 @@
       "integrity": "sha1-DeKxYxupocLGuFcq0nfYd+hQNgA="
     },
     "keycode": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.1.9.tgz",
-      "integrity": "sha1-lkojxU5IiUBbSGGlyfBIDUUUHfo="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
+      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
     },
     "kind-of": {
       "version": "3.2.2",
@@ -9194,10 +9194,11 @@
       }
     },
     "prop-types-extra": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.0.1.tgz",
-      "integrity": "sha1-pXvUgQ6C0no/9DF+zBtK0AX3moI=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.0.tgz",
+      "integrity": "sha512-QFyuDxvMipmIVKD2TwxLVPzMnO4e5oOf1vr3tJIomL8E7d0lr6phTHd5nkPhFIzTD1idBLLEPeylL9g+rrTzRg==",
       "requires": {
+        "react-is": "16.4.1",
         "warning": "3.0.0"
       }
     },
@@ -9373,18 +9374,20 @@
       }
     },
     "react-bootstrap": {
-      "version": "0.31.5",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.31.5.tgz",
-      "integrity": "sha1-VwQPqLEnTh4HSAPCGhuJX9q+oFo=",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.32.1.tgz",
+      "integrity": "sha512-RbfzKUbsukWsToWqGHfCCyMFq9QQI0TznutdyxyJw6dih2NvIne25Mrssg8LZsprqtPpyQi8bN0L0Fx3fUsL8Q==",
       "requires": {
         "babel-runtime": "6.26.0",
-        "classnames": "2.2.5",
-        "dom-helpers": "3.2.1",
+        "classnames": "2.2.6",
+        "dom-helpers": "3.3.1",
         "invariant": "2.2.2",
-        "keycode": "2.1.9",
+        "keycode": "2.2.0",
         "prop-types": "15.6.1",
-        "prop-types-extra": "1.0.1",
-        "react-overlays": "0.7.4",
+        "prop-types-extra": "1.1.0",
+        "react-overlays": "0.8.3",
+        "react-prop-types": "0.4.0",
+        "react-transition-group": "2.3.1",
         "uncontrollable": "4.1.0",
         "warning": "3.0.0"
       }
@@ -9603,20 +9606,34 @@
         "superagent": "1.7.2"
       }
     },
+    "react-is": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.1.tgz",
+      "integrity": "sha512-xpb0PpALlFWNw/q13A+1aHeyJyLYCg0/cCHPUA43zYluZuIPHaHL3k8OBsTgQtxqW0FhyDEMvi8fZ/+7+r4OSQ=="
+    },
     "react-moment": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/react-moment/-/react-moment-0.7.0.tgz",
       "integrity": "sha1-nMtch75oPQjCU7SEaRZ0Q/CcPYk="
     },
     "react-overlays": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.7.4.tgz",
-      "integrity": "sha1-7y7GUsNESriqAUJisY9mIGjlbVw=",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.8.3.tgz",
+      "integrity": "sha512-h6GT3jgy90PgctleP39Yu3eK1v9vaJAW73GOA/UbN9dJ7aAN4BTZD6793eI1D5U+ukMk17qiqN/wl3diK1Z5LA==",
       "requires": {
-        "classnames": "2.2.5",
-        "dom-helpers": "3.2.1",
+        "classnames": "2.2.6",
+        "dom-helpers": "3.3.1",
         "prop-types": "15.6.1",
-        "prop-types-extra": "1.0.1",
+        "prop-types-extra": "1.1.0",
+        "react-transition-group": "2.3.1",
+        "warning": "3.0.0"
+      }
+    },
+    "react-prop-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",
+      "integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=",
+      "requires": {
         "warning": "3.0.0"
       }
     },
@@ -10029,6 +10046,16 @@
       "integrity": "sha1-obh5WJdhGNzuCTgf0wsOawIzyb4=",
       "requires": {
         "jump.js": "1.0.1",
+        "prop-types": "15.6.1"
+      }
+    },
+    "react-transition-group": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.3.1.tgz",
+      "integrity": "sha512-hu4/LAOFSKjWt1+1hgnOv3ldxmt6lvZGTWz4KUkFrqzXrNDIVSu6txIcPszw7PNduR8en9YTN55JLRyd/L1ZiQ==",
+      "requires": {
+        "dom-helpers": "3.3.1",
+        "loose-envify": "1.3.1",
         "prop-types": "15.6.1"
       }
     },

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,7 @@
     "prop-types": "^15.6.1",
     "query-string": "^5.0.0",
     "react": "^15.6.2",
-    "react-bootstrap": "^0.31.0",
+    "react-bootstrap": "^0.32.1",
     "react-dom": "^15.6.2",
     "react-http-request": "^1.0.4",
     "react-moment": "^0.7.0",

--- a/client/src/Components/Broadcast/Broadcast.js
+++ b/client/src/Components/Broadcast/Broadcast.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import Moment from 'react-moment';
-import { Col, ControlLabel, Form, FormGroup, FormControl, Grid, PageHeader, Table } from 'react-bootstrap';
+import { Col, ControlLabel, Form, FormGroup, FormControl, Grid, PageHeader, Panel, Table } from 'react-bootstrap';
 import PropTypes from 'prop-types';
+import ContentfulLink from '../ContentfulLink';
 
 const helpers = require('../../helpers');
 
@@ -129,11 +130,17 @@ const Broadcast = (props) => {
   return (
     <Grid>
       <PageHeader>{helpers.broadcastName(broadcast)}</PageHeader>
-      <Form horizontal>
-        {broadcast.context}
-        {renderRow('Created', <Moment format="MMM D, YYYY">{broadcast.createdAt}</Moment>)}
-        {renderRow('Text', broadcast.message)}
-      </Form>
+      <Panel>
+        <Panel.Body>
+          <Form horizontal>
+            {broadcast.context}
+            {renderRow('Created', <Moment format="MMM D, YYYY">{broadcast.createdAt}</Moment>)}
+            {renderRow('Text', broadcast.message)}
+          </Form>
+          <ContentfulLink entryId={broadcast.id} />
+        </Panel.Body>
+      </Panel>
+
       <h2>Stats</h2>
       {renderStats(broadcast)}
       <h2>Settings</h2>

--- a/client/src/Components/CampaignDetail.js
+++ b/client/src/Components/CampaignDetail.js
@@ -54,7 +54,12 @@ class CampaignDetail extends React.Component {
                       <th>Triggers</th>
                       <th>Post type</th>
                     </tr>
-                    {campaign.topics.map(topic => <TopicListItem topic={topic} />)}
+                    {campaign.topics.map(topic => (
+                      <TopicListItem
+                        key={topic.id}
+                        topic={topic}
+                      />
+                    ))}
                   </tbody>
                 </Table>
               </div>

--- a/client/src/Components/CampaignDetail.js
+++ b/client/src/Components/CampaignDetail.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Col, Grid, PageHeader, Panel, Row, Tab, Tabs } from 'react-bootstrap';
+import { Grid, PageHeader, Panel, Tab, Tabs } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import TopicTemplate from './TopicDetail/TopicTemplate';
 import MessageList from './MessageList/MessageListContainer';
@@ -34,24 +34,24 @@ class CampaignDetail extends React.Component {
     }
     return (
       <Panel>
-        <Row>
-          <Col sm={12}><strong>Tagline:</strong> {campaign.tagline}</Col>
-        </Row>
-        <Row>
-          <Col sm={6}>
+        <Panel.Body>
+          <p>
+            <strong>Tagline:</strong> {campaign.tagline}
+          </p>
+          <p>
             <strong>Keywords:</strong> {keywords}
-          </Col>
-          <Col sm={6}>
+          </p>
+          <p>
             <strong>Status:</strong> {campaign.status}
-          </Col>
-        </Row>
+          </p>
+        </Panel.Body>
       </Panel>
     );
   }
 
   static renderTemplates(templates) {
     if (!templates) {
-      return <div>botConfig not found.</div>;
+      return <div>No topics found.</div>;
     }
     const templateNames = Object.keys(templates);
     const rows = templateNames.map((templateName) => {

--- a/client/src/Components/CampaignDetail.js
+++ b/client/src/Components/CampaignDetail.js
@@ -46,11 +46,12 @@ class CampaignDetail extends React.Component {
               <div>
                 <PageHeader>{campaign.title}</PageHeader>
                 {CampaignDetail.renderDetails(campaign)}
-                <h3>Current topics</h3>
+                <h3>Active topics</h3>
                 <Table striped hover>
                   <tbody>
                     <tr>
                       <th>Name</th>
+                      <th>Triggers</th>
                       <th>Post type</th>
                     </tr>
                     {campaign.topics.map(topic => <TopicListItem topic={topic} />)}

--- a/client/src/Components/CampaignDetail.js
+++ b/client/src/Components/CampaignDetail.js
@@ -1,32 +1,12 @@
 import React from 'react';
-import { Grid, PageHeader, Panel, Tab, Tabs } from 'react-bootstrap';
+import { Grid, PageHeader, Panel, Table } from 'react-bootstrap';
 import PropTypes from 'prop-types';
-import TopicTemplate from './TopicDetail/TopicTemplate';
-import MessageList from './MessageList/MessageListContainer';
+import TopicListItem from './TopicList/TopicListItem';
 import HttpRequest from './HttpRequest';
 
-const queryString = require('query-string');
 const helpers = require('../helpers');
 
 class CampaignDetail extends React.Component {
-  static renderNav(campaign) {
-    const queryParams = queryString.parse(window.location.search);
-    let defaultActiveKey = 0;
-    if (queryParams.skip) {
-      defaultActiveKey = 1;
-    }
-    return (
-      <Tabs defaultActiveKey={defaultActiveKey} animation={false} id="campaign-tabs">
-        <Tab eventKey={0} title="Templates"><br />
-          { CampaignDetail.renderTemplates(campaign.botConfig.templates) }
-        </Tab>
-        <Tab eventKey={1} title="Messages"><br />
-          <MessageList campaignId={campaign.id} />
-        </Tab>
-      </Tabs>
-    );
-  }
-
   static renderDetails(campaign) {
     let keywords = null;
     if (campaign.keywords) {
@@ -49,22 +29,6 @@ class CampaignDetail extends React.Component {
     );
   }
 
-  static renderTemplates(templates) {
-    if (!templates) {
-      return <div>No topics found.</div>;
-    }
-    const templateNames = Object.keys(templates);
-    const rows = templateNames.map((templateName) => {
-      const data = templates[templateName];
-      return <TopicTemplate key={templateName} name={templateName} data={data} />;
-    });
-    return (
-      <Grid>
-        {rows}
-      </Grid>
-    );
-  }
-
   constructor(props) {
     super(props);
 
@@ -82,7 +46,16 @@ class CampaignDetail extends React.Component {
               <div>
                 <PageHeader>{campaign.title}</PageHeader>
                 {CampaignDetail.renderDetails(campaign)}
-                {CampaignDetail.renderNav(campaign)}
+                <h3>Current topics</h3>
+                <Table striped hover>
+                  <tbody>
+                    <tr>
+                      <th>Name</th>
+                      <th>Post type</th>
+                    </tr>
+                    {campaign.topics.map(topic => <TopicListItem topic={topic} />)}
+                  </tbody>
+                </Table>
               </div>
             )
           }

--- a/client/src/Components/CampaignList.js
+++ b/client/src/Components/CampaignList.js
@@ -8,6 +8,7 @@ const helpers = require('../helpers');
 export default class CampaignList extends React.Component {
   static renderRow(campaign) {
     const campaignId = campaign.id;
+    const triggers = campaign.topics[0].triggers;
 
     return (
       <tr key={campaignId}>
@@ -18,6 +19,7 @@ export default class CampaignList extends React.Component {
           </Link>
         </td>
         <td>{campaign.keywords.join(', ')}</td>
+        <td>{triggers ? triggers.join(', ') : null}</td>
         <td>{campaign.status}</td>
       </tr>
     );
@@ -41,6 +43,7 @@ export default class CampaignList extends React.Component {
                   <th>ID</th>
                   <th>Title</th>
                   <th>Keywords</th>
+                  <th>Triggers</th>
                   <th>Status</th>
                 </tr>
                 {res.map(campaign => CampaignList.renderRow(campaign))}

--- a/client/src/Components/ContentfulLink.js
+++ b/client/src/Components/ContentfulLink.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from 'react-bootstrap';
+
+const helpers = require('../helpers');
+
+class ContentfulLink extends React.Component {
+  constructor(props) {
+    super(props);
+    this.url = helpers.getContentfulUrlForEntryId(this.props.entryId);
+  }
+
+  render() {
+    return (
+      <Button href={this.url} target="_blank">Edit in Contentful</Button>
+    );
+  }
+}
+
+ContentfulLink.propTypes = {
+  entryId: PropTypes.string.isRequired,
+};
+
+export default ContentfulLink;

--- a/client/src/Components/ContentfulLink.js
+++ b/client/src/Components/ContentfulLink.js
@@ -12,7 +12,7 @@ class ContentfulLink extends React.Component {
 
   render() {
     return (
-      <Button href={this.url} target="_blank">Edit in Contentful</Button>
+      <Button href={this.url} target="_blank" rel="noopener noreferrer">Edit in Contentful</Button>
     );
   }
 }

--- a/client/src/Components/TopicDetail/TopicDetail.js
+++ b/client/src/Components/TopicDetail/TopicDetail.js
@@ -18,13 +18,16 @@ function renderTemplates(templates) {
 
 const TopicDetail = (props) => {
   const topic = props.topic;
+  const postType = topic.postType;
   const editLink = <small><Link to="/">edit</Link></small>;
   const campaignId = topic.campaign.id;
   return (
     <Grid>
       <PageHeader>{topic.name} <small>{editLink}</small></PageHeader>
       <Panel>
-        <Panel.Body>Creates <strong>{topic.postType}</strong> posts for campaign <strong>{campaignId}</strong>.</Panel.Body>
+        <Panel.Body>
+          Creates <strong>{postType}</strong> posts for campaign <strong>{campaignId}</strong>.
+        </Panel.Body>
       </Panel>
       {renderTemplates(topic.templates)}
     </Grid>

--- a/client/src/Components/TopicDetail/TopicDetail.js
+++ b/client/src/Components/TopicDetail/TopicDetail.js
@@ -28,6 +28,7 @@ const TopicDetail = (props) => {
       <Panel>
         <Panel.Body>
           <p>{description}</p>
+          <p><strong>Triggers:</strong> {topic.triggers.join(', ')}</p>
           <ContentfulLink entryId={topic.id} />
         </Panel.Body>
       </Panel>

--- a/client/src/Components/TopicDetail/TopicDetail.js
+++ b/client/src/Components/TopicDetail/TopicDetail.js
@@ -1,46 +1,32 @@
 import React from 'react';
-import { Col, Panel, Grid, PageHeader, Row } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
+import { Panel, Grid, PageHeader } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import TopicTemplate from './TopicTemplate';
 
-function topicInfo(topic) {
-  return (
-    <Panel>
-      <Row>
-        <Col sm={6}>
-          <strong>Type:</strong> {topic.type}
-        </Col>
-        <Col sm={6}>
-          <strong>Campaign:</strong> {topic.campaign ? topic.campaign.id : null}
-        </Col>
-      </Row>
-    </Panel>
-  );
-}
 
-function topicTemplates(templates) {
+function renderTemplates(templates) {
   if (!templates) {
     return <div>No templates found.</div>;
   }
   const templateNames = Object.keys(templates);
-  const rows = templateNames.map((templateName) => {
+  return templateNames.map((templateName) => {
     const data = templates[templateName];
     return <TopicTemplate key={templateName} name={templateName} data={data} />;
   });
-  return (
-    <Grid>
-      {rows}
-    </Grid>
-  );
 }
 
 const TopicDetail = (props) => {
   const topic = props.topic;
+  const editLink = <small><Link to="/">edit</Link></small>;
+  const campaignId = topic.campaign.id;
   return (
     <Grid>
-      <PageHeader>{topic.id}</PageHeader>
-      {topicInfo(topic)}
-      {topicTemplates(topic.templates)}
+      <PageHeader>{topic.name} <small>{editLink}</small></PageHeader>
+      <Panel>
+        <Panel.Body>Creates <strong>{topic.postType}</strong> posts for campaign <strong>{campaignId}</strong>.</Panel.Body>
+      </Panel>
+      {renderTemplates(topic.templates)}
     </Grid>
   );
 };

--- a/client/src/Components/TopicDetail/TopicDetail.js
+++ b/client/src/Components/TopicDetail/TopicDetail.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Panel, Grid, PageHeader } from 'react-bootstrap';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import TopicTemplate from './TopicTemplate';
 import ContentfulLink from '../ContentfulLink';
 
@@ -19,15 +20,16 @@ const TopicDetail = (props) => {
   const topic = props.topic;
   const postType = topic.postType;
   const campaignId = topic.campaign ? topic.campaign.id : '--';
-  /* eslint-disable max-len */
-  const description = <p>Creates signups and <strong>{postType}</strong> posts for campaign <strong>{campaignId}</strong>.</p>;
-  /* eslint-enable max-len */
+  const campaignLink = (
+    <Link to={`/campaigns/${campaignId}`}>campaign <strong>{campaignId}</strong></Link>
+  );
+
   return (
     <Grid>
       <PageHeader>{topic.name}</PageHeader>
       <Panel>
         <Panel.Body>
-          <p>{description}</p>
+          <p>Creates signups and <strong>{postType}</strong> posts for {campaignLink}.</p>
           <p><strong>Triggers:</strong> {topic.triggers.join(', ')}</p>
           <ContentfulLink entryId={topic.id} />
         </Panel.Body>

--- a/client/src/Components/TopicDetail/TopicDetail.js
+++ b/client/src/Components/TopicDetail/TopicDetail.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Button, Panel, Grid, PageHeader } from 'react-bootstrap';
+import { Panel, Grid, PageHeader } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import TopicTemplate from './TopicTemplate';
-
+import ContentfulLink from '../ContentfulLink';
 
 function renderTemplates(templates) {
   if (!templates) {
@@ -19,19 +18,17 @@ function renderTemplates(templates) {
 const TopicDetail = (props) => {
   const topic = props.topic;
   const postType = topic.postType;
-  const url = `https://app.contentful.com/spaces/owik07lyerdj/entries/${topic.id}`;
   const campaignId = topic.campaign ? topic.campaign.id : '--';
+  /* eslint-disable max-len */
+  const description = <p>Creates signups and <strong>{postType}</strong> posts for campaign <strong>{campaignId}</strong>.</p>;
+  /* eslint-enable max-len */
   return (
     <Grid>
       <PageHeader>{topic.name}</PageHeader>
       <Panel>
         <Panel.Body>
-          <p>
-            Creates <strong>{postType}</strong> posts for campaign <strong>{campaignId}</strong>.
-          </p>
-          <p>
-            <Button href={url} target="_blank">Edit in Contentful</Button>
-          </p>
+          <p>{description}</p>
+          <ContentfulLink entryId={topic.id} />
         </Panel.Body>
       </Panel>
       {renderTemplates(topic.templates)}

--- a/client/src/Components/TopicDetail/TopicDetail.js
+++ b/client/src/Components/TopicDetail/TopicDetail.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Panel, Grid, PageHeader } from 'react-bootstrap';
+import { Button, Panel, Grid, PageHeader } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import TopicTemplate from './TopicTemplate';
 
@@ -19,14 +19,19 @@ function renderTemplates(templates) {
 const TopicDetail = (props) => {
   const topic = props.topic;
   const postType = topic.postType;
-  const editLink = <small><Link to="/">edit</Link></small>;
-  const campaignId = topic.campaign.id;
+  const url = `https://app.contentful.com/spaces/owik07lyerdj/entries/${topic.id}`;
+  const campaignId = topic.campaign ? topic.campaign.id : '--';
   return (
     <Grid>
-      <PageHeader>{topic.name} <small>{editLink}</small></PageHeader>
+      <PageHeader>{topic.name}</PageHeader>
       <Panel>
         <Panel.Body>
-          Creates <strong>{postType}</strong> posts for campaign <strong>{campaignId}</strong>.
+          <p>
+            Creates <strong>{postType}</strong> posts for campaign <strong>{campaignId}</strong>.
+          </p>
+          <p>
+            <Button href={url} target="_blank">Edit in Contentful</Button>
+          </p>
         </Panel.Body>
       </Panel>
       {renderTemplates(topic.templates)}

--- a/client/src/Components/TopicDetail/TopicTemplate.js
+++ b/client/src/Components/TopicDetail/TopicTemplate.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ScrollableAnchor from 'react-scrollable-anchor';
-import { Panel, Row } from 'react-bootstrap';
+import { Panel } from 'react-bootstrap';
 
 class TopicTemplate extends React.Component {
   constructor(props) {
@@ -16,16 +16,18 @@ class TopicTemplate extends React.Component {
 
   render() {
     const name = this.props.name;
-
     return (
-      <Row id={name} key={name}>
-        <Panel>
+      <Panel id={name} key={name}>
+        <Panel.Heading>
           <ScrollableAnchor id={name}>
-            <h4><a href={`#${name}`}># {name}{this.suffix}</a></h4>
+            <Panel.Title componentClass="h3">
+              <a href={`#${name}`}>{name}{this.suffix}</a>
+            </Panel.Title>
           </ScrollableAnchor>
-          <p>{this.props.data.rendered}</p>
-        </Panel>
-      </Row>
+        </Panel.Heading>
+        <Panel.Body>{this.props.data.rendered}</Panel.Body>
+      </Panel>
+     
     );
   }
 }

--- a/client/src/Components/TopicDetail/TopicTemplate.js
+++ b/client/src/Components/TopicDetail/TopicTemplate.js
@@ -27,7 +27,6 @@ class TopicTemplate extends React.Component {
         </Panel.Heading>
         <Panel.Body>{this.props.data.rendered}</Panel.Body>
       </Panel>
-     
     );
   }
 }

--- a/client/src/Components/TopicList/TopicListContainer.js
+++ b/client/src/Components/TopicList/TopicListContainer.js
@@ -22,7 +22,7 @@ export default class TopicListContainer extends React.Component {
               <Table striped hover>
                 <tbody>
                   <tr>
-                    <th>ID</th>
+                    <th>Topic</th>
                     <th>Post type</th>
                     <th>Campaign</th>
                   </tr>

--- a/client/src/Components/TopicList/TopicListContainer.js
+++ b/client/src/Components/TopicList/TopicListContainer.js
@@ -23,6 +23,7 @@ export default class TopicListContainer extends React.Component {
                 <tbody>
                   <tr>
                     <th>Topic</th>
+                    <th>Triggers</th>
                     <th>Post type</th>
                     <th>Campaign</th>
                   </tr>

--- a/client/src/Components/TopicList/TopicListItem.js
+++ b/client/src/Components/TopicList/TopicListItem.js
@@ -6,14 +6,17 @@ const TopicListItem = (props) => {
   const topic = props.topic;
   const topicId = topic.id;
   const url = `/topics/${topicId}`;
-
+  let campaignCell = null;
+  if (topic.campaign) {
+    campaignCell = <td>{topic.campaign.id}</td>;
+  }
   return (
     <tr key={topicId}>
       <td>
         <Link to={url}>{topic.name}</Link>
       </td>
       <td>{topic.postType}</td>
-      <td>{topic.campaign ? topic.campaign.id : null}</td>
+      {campaignCell}
     </tr>
   );
 };

--- a/client/src/Components/TopicList/TopicListItem.js
+++ b/client/src/Components/TopicList/TopicListItem.js
@@ -10,7 +10,7 @@ const TopicListItem = (props) => {
   return (
     <tr key={topicId}>
       <td>
-        <Link to={url}>{topicId}</Link>
+        <Link to={url}>{topic.name}</Link>
       </td>
       <td>{topic.postType}</td>
       <td>{topic.campaign ? topic.campaign.id : null}</td>

--- a/client/src/Components/TopicList/TopicListItem.js
+++ b/client/src/Components/TopicList/TopicListItem.js
@@ -15,6 +15,7 @@ const TopicListItem = (props) => {
       <td>
         <Link to={url}>{topic.name}</Link>
       </td>
+      <td>{topic.triggers ? topic.triggers.join(', ') : null}</td>
       <td>{topic.postType}</td>
       {campaignCell}
     </tr>

--- a/client/src/Components/TopicList/TopicListItem.js
+++ b/client/src/Components/TopicList/TopicListItem.js
@@ -6,10 +6,7 @@ const TopicListItem = (props) => {
   const topic = props.topic;
   const topicId = topic.id;
   const url = `/topics/${topicId}`;
-  let campaignCell = null;
-  if (topic.campaign) {
-    campaignCell = <td>{topic.campaign.id}</td>;
-  }
+  const campaignCell = topic.campaign ? <td>{topic.campaign.id}</td> : null;
   return (
     <tr key={topicId}>
       <td>

--- a/client/src/Components/UserDetail/UserDetail.js
+++ b/client/src/Components/UserDetail/UserDetail.js
@@ -114,35 +114,37 @@ function userInfo(user) {
 
   return (
     <Panel>
-      <Row>
-        <Col sm={6}>
-          <strong>Mobile:</strong> {user.mobile}
-        </Col>
-        <Col sm={6}>
-          <strong>SMS Status:</strong> {user.sms_status}
-        </Col>
-      </Row>
-      <Row>
-        <Col sm={6}>
-          <strong>Email:</strong> {user.email}
-        </Col>
-        <Col sm={6}>
-          <strong>SMS Last Inbound:</strong> {lastMessagedDate}
-        </Col>
-      </Row>
-      <Row>
-        <Col sm={6}>
-          <strong>Address:</strong> {address} {addressSource}
-        </Col>
-        <Col sm={6}>
-          <strong>Links:</strong> {links}
-        </Col>
-      </Row>
-      <Row>
-        <Col sm={12}>
-          <strong>Member Since:</strong> {registrationDate} {registrationSource}
-        </Col>
-      </Row>
+      <Panel.Body>
+        <Row>
+          <Col sm={6}>
+            <strong>Mobile:</strong> {user.mobile}
+          </Col>
+          <Col sm={6}>
+            <strong>SMS Status:</strong> {user.sms_status}
+          </Col>
+        </Row>
+        <Row>
+          <Col sm={6}>
+            <strong>Email:</strong> {user.email}
+          </Col>
+          <Col sm={6}>
+            <strong>SMS Last Inbound:</strong> {lastMessagedDate}
+          </Col>
+        </Row>
+        <Row>
+          <Col sm={6}>
+            <strong>Address:</strong> {address} {addressSource}
+          </Col>
+          <Col sm={6}>
+            <strong>Links:</strong> {links}
+          </Col>
+        </Row>
+        <Row>
+          <Col sm={12}>
+            <strong>Member Since:</strong> {registrationDate} {registrationSource}
+          </Col>
+        </Row>
+      </Panel.Body>
     </Panel>
   );
 }

--- a/client/src/Components/UserDetail/UserDetail.js
+++ b/client/src/Components/UserDetail/UserDetail.js
@@ -120,7 +120,7 @@ function userInfo(user) {
             <strong>Mobile:</strong> {user.mobile}
           </Col>
           <Col sm={6}>
-            <strong>SMS Status:</strong> {user.sms_status}
+            <strong>SMS status:</strong> {user.sms_status}
           </Col>
         </Row>
         <Row>
@@ -128,7 +128,7 @@ function userInfo(user) {
             <strong>Email:</strong> {user.email}
           </Col>
           <Col sm={6}>
-            <strong>SMS Last Inbound:</strong> {lastMessagedDate}
+            <strong>Last inbound SMS:</strong> {lastMessagedDate}
           </Col>
         </Row>
         <Row>
@@ -141,7 +141,7 @@ function userInfo(user) {
         </Row>
         <Row>
           <Col sm={12}>
-            <strong>Member Since:</strong> {registrationDate} {registrationSource}
+            <strong>User created:</strong> {registrationDate} {registrationSource}
           </Col>
         </Row>
       </Panel.Body>

--- a/client/src/helpers.js
+++ b/client/src/helpers.js
@@ -18,6 +18,14 @@ function getHardcodedTopics() {
   ];
 }
 
+/**
+ * @param {String}
+ * @return {String}
+ */
+function getContentfulUrlForEntryId(entryId) {
+  return `https://app.contentful.com/spaces/owik07lyerdj/entries/${entryId}`;
+}
+
 module.exports = {
   /**
    * Returns localhost API url for given path and query object.
@@ -43,6 +51,7 @@ module.exports = {
   getCampaignsPath: function getCampaignsPath() {
     return 'campaigns';
   },
+  getContentfulUrlForEntryId,
   getConversationByIdPath: function getConversationByIdPath(conversationId) {
     return `${this.getConversationsPath()}/${conversationId}`;
   },


### PR DESCRIPTION
Frontend updates in tandem with https://github.com/DoSomething/gambit-campaigns/pull/1055

* Displays new topic name field

* Renders a topic list on a `CampaignDetail` instead of `TopicTemplate` components, linking to the various topics a campaign can have, removes tabs as the Campaign messages view didn't exactly work (query times out, and I don't think anyone's ever noticed or navigated to it)

* Updates React Bootstrap, and `Panel` components

* Adds a ` ContentfulLink` component to topic, broadcast detail views

Cleanup tasks for a separate PR:

* Split `CampaignDetail` and `CampaignList` components into separate container and content components like other components (e.g. `TopicDetail/TopicDetail.js, TopicDetail/TopicDetailContainer.js`

* Rename `Broadcast` component as `BroadcastDetail`