### PR TITLE
Removes campaign keywords

### DIFF
--- a/client/src/Components/CampaignDetail.js
+++ b/client/src/Components/CampaignDetail.js
@@ -8,18 +8,11 @@ const helpers = require('../helpers');
 
 class CampaignDetail extends React.Component {
   static renderDetails(campaign) {
-    let keywords = null;
-    if (campaign.keywords) {
-      keywords = campaign.keywords.join(', ');
-    }
     return (
       <Panel>
         <Panel.Body>
           <p>
             <strong>Tagline:</strong> {campaign.tagline}
-          </p>
-          <p>
-            <strong>Keywords:</strong> {keywords}
           </p>
           <p>
             <strong>Status:</strong> {campaign.status}

--- a/client/src/Components/CampaignList.js
+++ b/client/src/Components/CampaignList.js
@@ -18,7 +18,6 @@ export default class CampaignList extends React.Component {
             <strong>{campaign.title}</strong>
           </Link>
         </td>
-        <td>{campaign.keywords.join(', ')}</td>
         <td>{triggers ? triggers.join(', ') : null}</td>
         <td>{campaign.status}</td>
       </tr>
@@ -42,7 +41,6 @@ export default class CampaignList extends React.Component {
                 <tr>
                   <th>ID</th>
                   <th>Title</th>
-                  <th>Keywords</th>
                   <th>Triggers</th>
                   <th>Status</th>
                 </tr>


### PR DESCRIPTION
Now that our changeTopicMacro triggers are published having deployed https://github.com/DoSomething/gambit-campaigns/pull/1055/, I've made the following Contentful changes:
- archived all `keyword` entries
- updated the keyword field's help text in Contentful to indicate we should no longer be creating keyword entries, as we're no longer querying for them 

TBD on removing the content type from Contentful completely (could make sense to run an[export](https://www.contentful.com/developers/docs/tutorials/general/import-and-export/), or just rely on the Staff Pick google doc the campaigns team uses)