### PR TITLE
Renames ConversationList as UserList

### DIFF
--- a/client/src/Components/Main.js
+++ b/client/src/Components/Main.js
@@ -3,8 +3,7 @@ import { Switch, Route } from 'react-router-dom';
 
 import Home from './Home';
 import CampaignDetail from './CampaignDetail/CampaignDetailContainer';
-// TODO: Rename ConversationList as UserList
-import UserList from './ConversationList/ConversationListContainer';
+import UserList from './UserList/UserListContainer';
 import UserDetail from './UserDetail/UserDetailContainer';
 import ConversationRequest from './ConversationRequest';
 import BroadcastList from './BroadcastList/BroadcastListContainer';

--- a/client/src/Components/UserList/UserListContainer.js
+++ b/client/src/Components/UserList/UserListContainer.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Grid, Table } from 'react-bootstrap';
 import HttpRequest from '../HttpRequest';
-import ConversationListItem from './ConversationListItem';
+import UserListItem from './UserListItem';
 
 const queryString = require('query-string');
 const helpers = require('../../helpers');
 
-export default class ConversationListContainer extends React.Component {
+export default class UserListContainer extends React.Component {
   constructor(props) {
     super(props);
 
@@ -36,7 +36,7 @@ export default class ConversationListContainer extends React.Component {
                     <th>Topic</th>
                   </tr>
                   {res.data.map(conversation => (
-                    <ConversationListItem
+                    <UserListItem
                       key={conversation._id}
                       conversation={conversation}
                     />

--- a/client/src/Components/UserList/UserListItem.js
+++ b/client/src/Components/UserList/UserListItem.js
@@ -7,7 +7,7 @@ import Moment from 'react-moment';
 const config = require('../../config');
 const helpers = require('../../helpers');
 
-const ConversationListItem = (props) => {
+const UserListItem = (props) => {
   const conversation = props.conversation;
   const identifier = helpers.getUserIdentifierForConversation(conversation);
   let platformLabel = '';
@@ -27,8 +27,8 @@ const ConversationListItem = (props) => {
   );
 };
 
-ConversationListItem.propTypes = {
+UserListItem.propTypes = {
   conversation: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 
-export default ConversationListItem;
+export default UserListItem;


### PR DESCRIPTION
Even though this component queries the Gambit `/conversations` index endpoint, it links to `UserDetail` views, and is presented under the `Users` parent view -- so it felt cleaner to rename as `UserList`.