### PR TITLE
Fixes breaking broadcasts API changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,8 @@ DS_GAMBIT_ADMIN_BASIC_AUTH_PASS=sloth
 
 DS_GAMBIT_CAMPAIGNS_API_BASEURI=https://ds-mdata-responder-staging.herokuapp.com/api/v1
 
-DS_GAMBIT_CONVERSATIONS_API_BASEURI=https://gambit-conversations-staging.herokuapp.com/api/v1
+// Note: we don't prefix with api version as we need to query both v1 and v2
+DS_GAMBIT_CONVERSATIONS_API_BASEURI=https://gambit-conversations-staging.herokuapp.com/api
 DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_NAME=puppet
 DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_PASS=secret
 

--- a/client/src/Components/BroadcastDetail/BroadcastDetail.js
+++ b/client/src/Components/BroadcastDetail/BroadcastDetail.js
@@ -130,9 +130,6 @@ const BroadcastDetail = (props) => {
     const campaignLink = `/campaigns/${campaignId}`;
     broadcast.context = renderRow('Campaign', <Link to={campaignLink}>{campaignId}</Link>);
   }
-  // TODO: Remove this check after https://github.com/DoSomething/gambit-conversations/pull/368 is
-  // deployed to Gambit Conversations.
-  const broadcastMessageText = broadcast.message.text || broadcast.message;
 
   return (
     <div>
@@ -141,7 +138,7 @@ const BroadcastDetail = (props) => {
         <Panel.Body>
           {broadcast.context}
           {renderRow('Created', <Moment format="MMM D, YYYY">{broadcast.createdAt}</Moment>)}
-          {renderRow('Text', broadcastMessageText)}
+          {renderRow('Text', broadcast.message.text)}
           <ContentfulLink entryId={broadcast.id} />
         </Panel.Body>
       </Panel>

--- a/client/src/Components/BroadcastList/BroadcastListItem.js
+++ b/client/src/Components/BroadcastList/BroadcastListItem.js
@@ -16,9 +16,6 @@ const BroadcastListItem = (props) => {
     const url = `/campaigns/${campaignId}`;
     context = <small>Campaign: <Link to={url}>{campaignId}</Link></small>;
   }
-  // TODO: Remove this check after https://github.com/DoSomething/gambit-conversations/pull/368 is
-  // deployed to Gambit Conversations.
-  const broadcastMessageText = broadcast.message.text || broadcast.message;
 
   return (
     <tr key={broadcastId}>
@@ -28,7 +25,7 @@ const BroadcastListItem = (props) => {
         </h4>
         <small><Moment format="MM/DD/YYYY">{broadcast.createdAt}</Moment></small>
         <p>{context}</p>
-        <p>{broadcastMessageText}</p>
+        <p>{broadcast.message.text}</p>
       </td>
     </tr>
   );

--- a/lib/gambit-conversations.js
+++ b/lib/gambit-conversations.js
@@ -44,21 +44,21 @@ function executeGet(path, query = {}, format = true) {
 }
 
 module.exports.getConversations = function (query) {
-  return executeGet('conversations', query);
+  return executeGet('v1/conversations', query);
 };
 
 module.exports.getConversationById = function (conversationId) {
-  return executeGet(`conversations/${conversationId}`);
+  return executeGet(`v1/conversations/${conversationId}`);
 };
 
 module.exports.getMessages = function (query) {
-  return executeGet('messages', query);
+  return executeGet('v1/messages', query);
 };
 
 module.exports.getBroadcasts = function (query) {
-  return executeGet('broadcasts', query);
+  return executeGet('v2/broadcasts', query, false);
 };
 
 module.exports.getBroadcastById = function (broadcastId) {
-  return executeGet(`broadcasts/${broadcastId}`, {}, false);
+  return executeGet(`v2/broadcasts/${broadcastId}`, {}, false);
 };


### PR DESCRIPTION
* Adds support to query Conversations API v1 and v2 per https://github.com/DoSomething/gambit-conversations/pull/371

    * NOTE: Requires changing `DS_GAMBIT_CONVERSATIONS_API_BASEURI` to remove `v1` after deploy. Because this app is not user facing, we can get away with changing the variable immediately after deploy.

* Cleanup TODOs from #62 