### PR TITLE
Adds broadcast pager

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,13 +10,13 @@ DS_GAMBIT_CONVERSATIONS_API_BASEURI=https://gambit-conversations-staging.herokua
 DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_NAME=puppet
 DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_PASS=secret
 
-DS_NORTHSTAR_API_BASEURI=https://northstar-thor.dosomething.org/v1
+DS_NORTHSTAR_API_BASEURI=https://identity-qa.dosomething.org/v1
 DS_NORTHSTAR_API_KEY=secret
 
-DS_ROGUE_BASEURI=https://rogue-thor.dosomething.org
+DS_ROGUE_BASEURI=https://activity-qa.dosomething.org
 DS_ROGUE_API_KEY=secret
 
-DS_AURORA_PROFILE_BASEURI=https://aurora-thor.dosomething.org/users
+DS_AURORA_PROFILE_BASEURI=https://admin-qa.dosomething.org/users
 DS_CUSTOMERIO_PROFILE_BASEURI=https://fly.customer.io/env/63704/people
 
 ## Client

--- a/client/src/Components/BroadcastList/BroadcastListContainer.js
+++ b/client/src/Components/BroadcastList/BroadcastListContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid, PageHeader, Table } from 'react-bootstrap';
+import { Grid, Table } from 'react-bootstrap';
 import HttpRequest from '../HttpRequest';
 import BroadcastListItem from './BroadcastListItem';
 
@@ -15,8 +15,7 @@ export default class BroadcastListContainer extends React.Component {
   render() {
     return (
       <Grid>
-        <PageHeader>Broadcasts</PageHeader>
-        <HttpRequest path={this.requestPath}>
+        <HttpRequest path={this.requestPath} description="broadcasts">
           {
             res => (
               <Table>

--- a/client/src/Components/HttpRequest.js
+++ b/client/src/Components/HttpRequest.js
@@ -45,8 +45,8 @@ class HttpRequest extends React.Component {
             let totalResultCount = 0;
             let pager = null;
             const body = result.body;
-            if (body && body.pagination && body.pagination.total) {
-              totalResultCount = body.pagination.total;
+            if (body && body.meta && body.meta.pagination && body.meta.pagination.total) {
+              totalResultCount = body.meta.pagination.total;
               pager = (
                 <ListPager
                   totalResultCount={totalResultCount}

--- a/client/src/Components/HttpRequest.js
+++ b/client/src/Components/HttpRequest.js
@@ -58,7 +58,11 @@ class HttpRequest extends React.Component {
               );
             }
             return (
-              <div>{pager}{this.props.children(body)}</div>
+              <div>
+                {pager}
+                {this.props.children(body)}
+                {totalResultCount > pageSize ? pager : null}
+              </div>
             );
           }
         }

--- a/client/src/Components/HttpRequest.js
+++ b/client/src/Components/HttpRequest.js
@@ -10,6 +10,17 @@ const config = require('../config');
 
 const pageSize = config.resultsPageSize;
 
+/**
+ * @param {Object} res
+ * @return {Number}
+ */
+function getPaginationTotal(body) {
+  if (body && body.meta && body.meta.pagination) {
+    return body.meta.pagination.total;
+  }
+  return 0;
+}
+
 class HttpRequest extends React.Component {
   constructor(props) {
     super(props);
@@ -42,11 +53,10 @@ class HttpRequest extends React.Component {
                 </Panel>
               );
             }
-            let totalResultCount = 0;
-            let pager = null;
             const body = result.body;
-            if (body && body.meta && body.meta.pagination && body.meta.pagination.total) {
-              totalResultCount = body.meta.pagination.total;
+            const totalResultCount = getPaginationTotal(body);
+            let pager = null;
+            if (totalResultCount) {
               pager = (
                 <ListPager
                   totalResultCount={totalResultCount}

--- a/config/lib/gambit-conversations.js
+++ b/config/lib/gambit-conversations.js
@@ -6,6 +6,8 @@ const configVars = {
     pass: process.env.DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_PASS,
   },
   baseUri: process.env.DS_GAMBIT_CONVERSATIONS_API_BASEURI,
+  // @see https://github.com/DoSomething/gambit-conversations/blob/7bab3025e38630b938cba844c6755bba5c2373e7/config/app/routes/mongoose.js#L4
+  resultsCountHeader: 'x-gambit-results-count',
 };
 
 module.exports = configVars;

--- a/lib/gambit-conversations.js
+++ b/lib/gambit-conversations.js
@@ -8,21 +8,16 @@ const config = require('../config/lib/gambit-conversations');
  * @param {object} res - Express response
  * @return {object}
  */
-function formatV1Response(res) {
-  const result = {
+function formatV1IndexResponse(res) {
+  const total = Number(res.header[config.resultsCountHeader]) || 0;
+  return {
     data: res.body,
     meta: {
       pagination: {
-        total: 0,
+        total,
       },
     },
   };
-  const total = res.header['x-gambit-results-count'];
-  if (total) {
-    result.meta.pagination.total = Number(total);
-  }
-
-  return result;
 }
 
 /**
@@ -32,37 +27,34 @@ function formatV1Response(res) {
  */
 function executeGet(path, query = {}) {
   const url = `${config.baseUri}/${path}`;
-  const auth = config.auth;
   logger.info('executeGet', { url, query });
 
   return superagent.get(url)
     .query(query)
-    .auth(auth.name, auth.pass)
-    .then((res) => {
-      if (path.startsWith('v1')) {
-        return formatV1Response(res);
-      }
-      return res.body;
-    })
-    .catch(err => err);
+    .auth(config.auth.name, config.auth.pass);
 }
 
 module.exports.getConversations = function (query) {
-  return executeGet('v1/conversations', query);
+  return executeGet('v1/conversations', query)
+    .then(res => formatV1IndexResponse(res));
 };
 
 module.exports.getConversationById = function (conversationId) {
-  return executeGet(`v1/conversations/${conversationId}`);
+  return executeGet(`v1/conversations/${conversationId}`)
+    .then(res => res.body);
 };
 
 module.exports.getMessages = function (query) {
-  return executeGet('v1/messages', query);
+  return executeGet('v1/messages', query)
+    .then(res => formatV1IndexResponse(res));
 };
 
 module.exports.getBroadcasts = function (query) {
-  return executeGet('v2/broadcasts', query, false);
+  return executeGet('v2/broadcasts', query)
+    .then(res => res.body);
 };
 
 module.exports.getBroadcastById = function (broadcastId) {
-  return executeGet(`v2/broadcasts/${broadcastId}`, {}, false);
+  return executeGet(`v2/broadcasts/${broadcastId}`)
+    .then(res => res.body);
 };

--- a/lib/gambit-conversations.js
+++ b/lib/gambit-conversations.js
@@ -8,16 +8,18 @@ const config = require('../config/lib/gambit-conversations');
  * @param {object} res - Express response
  * @return {object}
  */
-function formatResponse(res) {
+function formatV1Response(res) {
   const result = {
     data: res.body,
-    pagination: {
-      total: 0,
+    meta: {
+      pagination: {
+        total: 0,
+      },
     },
   };
   const total = res.header['x-gambit-results-count'];
   if (total) {
-    result.pagination.total = Number(total);
+    result.meta.pagination.total = Number(total);
   }
 
   return result;
@@ -28,7 +30,7 @@ function formatResponse(res) {
  * @param {object} query
  * @return {Promise}
  */
-function executeGet(path, query = {}, format = true) {
+function executeGet(path, query = {}) {
   const url = `${config.baseUri}/${path}`;
   const auth = config.auth;
   logger.info('executeGet', { url, query });
@@ -37,7 +39,9 @@ function executeGet(path, query = {}, format = true) {
     .query(query)
     .auth(auth.name, auth.pass)
     .then((res) => {
-      if (format) return formatResponse(res);
+      if (path.startsWith('v1')) {
+        return formatV1Response(res);
+      }
       return res.body;
     })
     .catch(err => err);


### PR DESCRIPTION
Updates the Conversations proxy response to return a `meta` object instead of `pagination` per https://github.com/DoSomething/gambit-campaigns/pull/1061.

Still need to add limit query parameter support in G-Campaigns to the `GET /broadcasts` index endpoint, opening this to test against that change (currently returns 100, but Gambit Admin has hardcoded limits of 50 for now -- which is why the results are incorrect on page 2 of broadcasts. Likewise could modify this app to have different page sizes per components, but doesn't seem worth the lift at the moment)