### PR TITLE
Adds cache clear button, broadcast templates [pr]

### DIFF
--- a/client/src/Components/BroadcastDetail/BroadcastDetail.js
+++ b/client/src/Components/BroadcastDetail/BroadcastDetail.js
@@ -136,10 +136,12 @@ const BroadcastDetail = (props) => {
       <PageHeader>{helpers.broadcastName(broadcast)}</PageHeader>
       <Panel>
         <Panel.Body>
+          <p>
+            <ContentfulLink entryId={broadcast.id} />
+          </p>
           {broadcast.context}
           {renderRow('Created', <Moment format="MMM D, YYYY">{broadcast.createdAt}</Moment>)}
           {renderRow('Text', broadcast.message.text)}
-          <ContentfulLink entryId={broadcast.id} />
         </Panel.Body>
       </Panel>
       <h2>Stats</h2>

--- a/client/src/Components/BroadcastDetail/BroadcastDetail.js
+++ b/client/src/Components/BroadcastDetail/BroadcastDetail.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import Moment from 'react-moment';
 import { Col, PageHeader, Panel, Row, Table } from 'react-bootstrap';
 import PropTypes from 'prop-types';
+import TopicTemplates from '../TopicDetail/TopicTemplates';
 import TopicTemplate from '../TopicDetail/TopicTemplate';
 import ContentfulLink from '../ContentfulLink';
 
@@ -136,7 +137,7 @@ const BroadcastDetail = (props) => {
     const campaignLink = `/campaigns/${campaignId}`;
     description = (
       <p>
-        This broadcast is for <Link to={campaignLink}>{campaignId}</Link>.
+        This broadcast is for campaign <Link to={campaignLink}>{campaignId}</Link>.
       </p>
     );
   }
@@ -144,9 +145,6 @@ const BroadcastDetail = (props) => {
   if (templateName === 'rivescript') {
     templateName = null;
   }
-  const templateData = {
-    rendered: broadcast.message.text,
-  };
 
   return (
     <div>
@@ -162,7 +160,8 @@ const BroadcastDetail = (props) => {
           <ContentfulLink entryId={broadcast.id} />
         </Panel.Body>
       </Panel>
-      <TopicTemplate name={templateName} data={templateData} />
+      <TopicTemplate name={templateName} data={broadcast.message} />
+      <TopicTemplates templates={broadcast.templates} />
       <h2>Stats</h2>
       {renderStats(broadcast)}
       <h2>Settings</h2>

--- a/client/src/Components/BroadcastDetail/BroadcastDetail.js
+++ b/client/src/Components/BroadcastDetail/BroadcastDetail.js
@@ -3,8 +3,8 @@ import { Link } from 'react-router-dom';
 import Moment from 'react-moment';
 import { Col, PageHeader, Panel, Row, Table } from 'react-bootstrap';
 import PropTypes from 'prop-types';
-import TopicTemplates from '../TopicDetail/TopicTemplates';
-import TopicTemplate from '../TopicDetail/TopicTemplate';
+import TemplateList from '../TemplateList/TemplateList';
+import TemplateListItem from '../TemplateList/TemplateListItem';
 import ContentfulLink from '../ContentfulLink';
 
 const helpers = require('../../helpers');
@@ -160,8 +160,8 @@ const BroadcastDetail = (props) => {
           <ContentfulLink entryId={broadcast.id} />
         </Panel.Body>
       </Panel>
-      <TopicTemplate name={templateName} data={broadcast.message} />
-      <TopicTemplates templates={broadcast.templates} />
+      <TemplateListItem name={templateName} data={broadcast.message} />
+      <TemplateList templates={broadcast.templates} />
       <h2>Stats</h2>
       {renderStats(broadcast)}
       <h2>Settings</h2>

--- a/client/src/Components/BroadcastDetail/BroadcastDetail.js
+++ b/client/src/Components/BroadcastDetail/BroadcastDetail.js
@@ -125,15 +125,9 @@ function renderStats(broadcast) {
 const BroadcastDetail = (props) => {
   const broadcast = props.broadcast;
   broadcast.webhookBody = JSON.stringify(broadcast.webhook.body, null, 2);
-  let description;
-  if (broadcast.topic) {
-    description = (
-      <p>
-        This broadcast sets the user conversation topic to <code>{broadcast.topic}</code>.
-      </p>
-    );
-  } else {
-    const campaignId = broadcast.campaignId;
+  const campaignId = broadcast.campaignId;
+  let description = null;
+  if (campaignId) {
     const campaignLink = `/campaigns/${campaignId}`;
     description = (
       <p>
@@ -141,19 +135,15 @@ const BroadcastDetail = (props) => {
       </p>
     );
   }
-  let templateName = broadcast.message.template;
-  if (templateName === 'rivescript') {
-    templateName = null;
-  }
+  const templateValue = broadcast.message.template;
+  const templateName = templateValue === 'rivescript' ? '' : templateValue;
 
   return (
     <div>
       <PageHeader>{helpers.broadcastName(broadcast)}</PageHeader>
       <Panel>
         <Panel.Body>
-          <p>
-            {description}
-          </p>
+          {description}
           <p>
             Created <strong><Moment format="MMM D, YYYY">{broadcast.createdAt}</Moment></strong>
           </p>

--- a/client/src/Components/BroadcastDetail/BroadcastDetail.js
+++ b/client/src/Components/BroadcastDetail/BroadcastDetail.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import Moment from 'react-moment';
 import { Col, PageHeader, Panel, Row, Table } from 'react-bootstrap';
 import PropTypes from 'prop-types';
+import TopicTemplate from '../TopicDetail/TopicTemplate';
 import ContentfulLink from '../ContentfulLink';
 
 const helpers = require('../../helpers');
@@ -123,13 +124,29 @@ function renderStats(broadcast) {
 const BroadcastDetail = (props) => {
   const broadcast = props.broadcast;
   broadcast.webhookBody = JSON.stringify(broadcast.webhook.body, null, 2);
+  let description;
   if (broadcast.topic) {
-    broadcast.context = renderRow('Topic', broadcast.topic);
+    description = (
+      <p>
+        This broadcast sets the user conversation topic to <code>{broadcast.topic}</code>.
+      </p>
+    );
   } else {
-    const campaignId = broadcast.campaignId;
+    const campaignId = broadcast.campaignId; 
     const campaignLink = `/campaigns/${campaignId}`;
-    broadcast.context = renderRow('Campaign', <Link to={campaignLink}>{campaignId}</Link>);
+    description = (
+      <p>
+        This broadcast is for <Link to={campaignLink}>{campaignId}</Link>.
+      </p>
+    );
   }
+  let templateName = broadcast.message.template;
+  if (templateName === 'rivescript') {
+    templateName = null;
+  }
+  const templateData = {
+    rendered: broadcast.message.text,
+  };
 
   return (
     <div>
@@ -137,13 +154,15 @@ const BroadcastDetail = (props) => {
       <Panel>
         <Panel.Body>
           <p>
-            <ContentfulLink entryId={broadcast.id} />
+            {description}
           </p>
-          {broadcast.context}
-          {renderRow('Created', <Moment format="MMM D, YYYY">{broadcast.createdAt}</Moment>)}
-          {renderRow('Text', broadcast.message.text)}
+          <p>
+            Created <strong><Moment format="MMM D, YYYY">{broadcast.createdAt}</Moment></strong>
+          </p>
+          <ContentfulLink entryId={broadcast.id} />
         </Panel.Body>
       </Panel>
+      <TopicTemplate name={templateName} data={templateData} />
       <h2>Stats</h2>
       {renderStats(broadcast)}
       <h2>Settings</h2>

--- a/client/src/Components/BroadcastDetail/BroadcastDetail.js
+++ b/client/src/Components/BroadcastDetail/BroadcastDetail.js
@@ -132,7 +132,7 @@ const BroadcastDetail = (props) => {
       </p>
     );
   } else {
-    const campaignId = broadcast.campaignId; 
+    const campaignId = broadcast.campaignId;
     const campaignLink = `/campaigns/${campaignId}`;
     description = (
       <p>

--- a/client/src/Components/BroadcastDetail/BroadcastDetailContainer.js
+++ b/client/src/Components/BroadcastDetail/BroadcastDetailContainer.js
@@ -1,24 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Grid } from 'react-bootstrap';
-import HttpRequest from '../HttpRequest';
 import queryString from 'query-string';
+import HttpRequest from '../HttpRequest';
 import BroadcastDetail from './BroadcastDetail';
 import helpers from '../../helpers';
 
-
-const BroadcastDetailContainer = (props) => {
-  return (
-    <Grid>
-      <HttpRequest
-        path={helpers.getBroadcastByIdPath(props.match.params.broadcastId)}
-        query={queryString.parse(window.location.search)}
-      >
+const BroadcastDetailContainer = props => (
+  <Grid>
+    <HttpRequest
+      path={helpers.getBroadcastByIdPath(props.match.params.broadcastId)}
+      query={queryString.parse(window.location.search)}
+    >
       {res => <BroadcastDetail broadcast={res.data} />}
-      </HttpRequest>
-    </Grid>
-  );
-}
+    </HttpRequest>
+  </Grid>
+);
 
 BroadcastDetailContainer.propTypes = {
   match: PropTypes.shape({

--- a/client/src/Components/BroadcastDetail/BroadcastDetailContainer.js
+++ b/client/src/Components/BroadcastDetail/BroadcastDetailContainer.js
@@ -2,33 +2,28 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Grid } from 'react-bootstrap';
 import HttpRequest from '../HttpRequest';
+import queryString from 'query-string';
 import BroadcastDetail from './BroadcastDetail';
+import helpers from '../../helpers';
 
-const helpers = require('../../helpers');
 
-class BroadcastContainer extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.broadcastId = this.props.match.params.broadcastId;
-    this.requestPath = helpers.getBroadcastByIdPath(this.broadcastId);
-  }
-
-  render() {
-    return (
-      <Grid>
-        <HttpRequest path={this.requestPath}>
-          {res => <BroadcastDetail broadcast={res.data} macro={this.macro} />}
-        </HttpRequest>
-      </Grid>
-    );
-  }
+const BroadcastDetailContainer = (props) => {
+  return (
+    <Grid>
+      <HttpRequest
+        path={helpers.getBroadcastByIdPath(props.match.params.broadcastId)}
+        query={queryString.parse(window.location.search)}
+      >
+      {res => <BroadcastDetail broadcast={res.data} />}
+      </HttpRequest>
+    </Grid>
+  );
 }
 
-BroadcastContainer.propTypes = {
+BroadcastDetailContainer.propTypes = {
   match: PropTypes.shape({
     params: PropTypes.shape({ broadcastId: PropTypes.string.isRequired }).isRequired,
   }).isRequired,
 };
 
-export default BroadcastContainer;
+export default BroadcastDetailContainer;

--- a/client/src/Components/ContentfulLink.js
+++ b/client/src/Components/ContentfulLink.js
@@ -1,21 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from 'react-bootstrap';
+import { Button, ButtonToolbar, Glyphicon } from 'react-bootstrap';
 
 const helpers = require('../helpers');
 
 const ContentfulLink = (props) => {
   const url = helpers.getContentfulUrlForEntryId(props.entryId);
   return (
-    <Button
-      href={url}
-      target="_blank"
-      rel="noopener noreferrer"
-      bsStyle={props.bsStyle}
-      bsSize={props.bsSize}
-    >
-      Edit
-    </Button>
+    <ButtonToolbar>
+      <Button
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        bsStyle={props.bsStyle}
+        bsSize={props.bsSize}
+      >
+        <Glyphicon glyph="pencil" />
+      </Button>
+      <Button
+        href="?cache=false"
+        bsStyle={props.bsStyle}
+        bsSize={props.bsSize}
+      >
+        <Glyphicon glyph="refresh" />
+      </Button>
+    </ButtonToolbar>
   );
 };
 

--- a/client/src/Components/ContentfulLink.js
+++ b/client/src/Components/ContentfulLink.js
@@ -5,11 +5,19 @@ import { Button, ButtonToolbar, Glyphicon } from 'react-bootstrap';
 const helpers = require('../helpers');
 
 const ContentfulLink = (props) => {
-  const url = helpers.getContentfulUrlForEntryId(props.entryId);
+  const refreshButton = (
+    <Button
+      href="?cache=false"
+      bsStyle={props.bsStyle}
+      bsSize={props.bsSize}
+    >
+      <Glyphicon glyph="refresh" />
+    </Button>
+  );
   return (
     <ButtonToolbar>
       <Button
-        href={url}
+        href={helpers.getContentfulUrlForEntryId(props.entryId)}
         target="_blank"
         rel="noopener noreferrer"
         bsStyle={props.bsStyle}
@@ -17,13 +25,7 @@ const ContentfulLink = (props) => {
       >
         <Glyphicon glyph="pencil" />
       </Button>
-      <Button
-        href="?cache=false"
-        bsStyle={props.bsStyle}
-        bsSize={props.bsSize}
-      >
-        <Glyphicon glyph="refresh" />
-      </Button>
+      { props.displayRefresh ? refreshButton : null }
     </ButtonToolbar>
   );
 };
@@ -32,11 +34,13 @@ ContentfulLink.propTypes = {
   entryId: PropTypes.string.isRequired,
   bsStyle: PropTypes.string,
   bsSize: PropTypes.string,
+  displayRefresh: PropTypes.bool,
 };
 
 ContentfulLink.defaultProps = {
   bsStyle: 'default',
   bsSize: 'small',
+  displayRefresh: true,
 };
 
 export default ContentfulLink;

--- a/client/src/Components/TemplateList/TemplateList.js
+++ b/client/src/Components/TemplateList/TemplateList.js
@@ -1,23 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import TopicTemplate from './TopicTemplate';
+import TemplateListItem from './TemplateListItem';
 
-const TopicTemplates = (props) => {
+const TemplateList = (props) => {
   const templates = props.templates;
   const templateNames = Object.keys(templates);
   const topicTemplates = templateNames.map((templateName) => {
     const data = templates[templateName];
-    return <TopicTemplate key={templateName} name={templateName} data={data} />;
+    return <TemplateListItem key={templateName} name={templateName} data={data} />;
   });
   return <div>{topicTemplates}</div>;
 };
 
-TopicTemplates.propTypes = {
+TemplateList.propTypes = {
   templates: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
-TopicTemplates.defaultProps = {
+TemplateList.defaultProps = {
   templates: {},
 };
 
-export default TopicTemplates;
+export default TemplateList;

--- a/client/src/Components/TemplateList/TemplateListItem.js
+++ b/client/src/Components/TemplateList/TemplateListItem.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ScrollableAnchor from 'react-scrollable-anchor';
 import { Panel } from 'react-bootstrap';
 
-const TopicTemplate = (props) => {
+const TemplateListItem = (props) => {
   const data = props.data;
   let suffix = '';
   if (data.override) {
@@ -25,9 +25,9 @@ const TopicTemplate = (props) => {
   );
 };
 
-TopicTemplate.propTypes = {
+TemplateListItem.propTypes = {
   data: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   name: PropTypes.string.isRequired,
 };
 
-export default TopicTemplate;
+export default TemplateListItem;

--- a/client/src/Components/TopicDetail/TopicDetail.js
+++ b/client/src/Components/TopicDetail/TopicDetail.js
@@ -2,19 +2,9 @@ import React from 'react';
 import { Panel, Grid, PageHeader } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import TopicTemplate from './TopicTemplate';
+import TopicTemplates from './TopicTemplates';
 import ContentfulLink from '../ContentfulLink';
 
-function renderTemplates(templates) {
-  if (!templates) {
-    return <div>No templates found.</div>;
-  }
-  const templateNames = Object.keys(templates);
-  return templateNames.map((templateName) => {
-    const data = templates[templateName];
-    return <TopicTemplate key={templateName} name={templateName} data={data} />;
-  });
-}
 
 const TopicDetail = (props) => {
   const topic = props.topic;
@@ -34,7 +24,7 @@ const TopicDetail = (props) => {
           <ContentfulLink entryId={topic.id} />
         </Panel.Body>
       </Panel>
-      {renderTemplates(topic.templates)}
+      <TopicTemplates templates={topic.templates} />
     </Grid>
   );
 };

--- a/client/src/Components/TopicDetail/TopicDetail.js
+++ b/client/src/Components/TopicDetail/TopicDetail.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Panel, Grid, PageHeader } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import TopicTemplates from './TopicTemplates';
+import TemplateList from '../TemplateList/TemplateList';
 import ContentfulLink from '../ContentfulLink';
 
 
@@ -24,7 +24,7 @@ const TopicDetail = (props) => {
           <ContentfulLink entryId={topic.id} />
         </Panel.Body>
       </Panel>
-      <TopicTemplates templates={topic.templates} />
+      <TemplateList templates={topic.templates} />
     </Grid>
   );
 };

--- a/client/src/Components/TopicDetail/TopicDetailContainer.js
+++ b/client/src/Components/TopicDetail/TopicDetailContainer.js
@@ -4,13 +4,15 @@ import { Grid } from 'react-bootstrap';
 import HttpRequest from '../HttpRequest';
 import TopicDetail from './TopicDetail';
 import helpers from '../../helpers';
+import queryString from 'query-string';
 
 const TopicDetailContainer = (props) => {
-  const topicId = props.match.params.topicId;
-  const requestPath = helpers.getTopicByIdPath(topicId);
   return (
     <Grid>
-      <HttpRequest path={requestPath}>
+      <HttpRequest
+        path={helpers.getTopicByIdPath(props.match.params.topicId)}
+        query={queryString.parse(window.location.search)}
+      >
         {res => <TopicDetail topic={res} />}
       </HttpRequest>
     </Grid>

--- a/client/src/Components/TopicDetail/TopicDetailContainer.js
+++ b/client/src/Components/TopicDetail/TopicDetailContainer.js
@@ -1,23 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Grid } from 'react-bootstrap';
+import queryString from 'query-string';
 import HttpRequest from '../HttpRequest';
 import TopicDetail from './TopicDetail';
 import helpers from '../../helpers';
-import queryString from 'query-string';
 
-const TopicDetailContainer = (props) => {
-  return (
-    <Grid>
-      <HttpRequest
-        path={helpers.getTopicByIdPath(props.match.params.topicId)}
-        query={queryString.parse(window.location.search)}
-      >
-        {res => <TopicDetail topic={res} />}
-      </HttpRequest>
-    </Grid>
-  );
-};
+const TopicDetailContainer = props => (
+  <Grid>
+    <HttpRequest
+      path={helpers.getTopicByIdPath(props.match.params.topicId)}
+      query={queryString.parse(window.location.search)}
+    >
+      {res => <TopicDetail topic={res} />}
+    </HttpRequest>
+  </Grid>
+);
 
 TopicDetailContainer.propTypes = {
   match: PropTypes.shape({

--- a/client/src/Components/TopicDetail/TopicDetailContainer.js
+++ b/client/src/Components/TopicDetail/TopicDetailContainer.js
@@ -3,27 +3,19 @@ import PropTypes from 'prop-types';
 import { Grid } from 'react-bootstrap';
 import HttpRequest from '../HttpRequest';
 import TopicDetail from './TopicDetail';
+import helpers from '../../helpers';
 
-const helpers = require('../../helpers');
-
-class TopicDetailContainer extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.topicId = this.props.match.params.topicId;
-    this.requestPath = helpers.getTopicByIdPath(this.topicId);
-  }
-
-  render() {
-    return (
-      <Grid>
-        <HttpRequest path={this.requestPath}>
-          {res => <TopicDetail topic={res} />}
-        </HttpRequest>
-      </Grid>
-    );
-  }
-}
+const TopicDetailContainer = (props) => {
+  const topicId = props.match.params.topicId;
+  const requestPath = helpers.getTopicByIdPath(topicId);
+  return (
+    <Grid>
+      <HttpRequest path={requestPath}>
+        {res => <TopicDetail topic={res} />}
+      </HttpRequest>
+    </Grid>
+  );
+};
 
 TopicDetailContainer.propTypes = {
   match: PropTypes.shape({

--- a/client/src/Components/TopicDetail/TopicTemplate.js
+++ b/client/src/Components/TopicDetail/TopicTemplate.js
@@ -3,33 +3,27 @@ import PropTypes from 'prop-types';
 import ScrollableAnchor from 'react-scrollable-anchor';
 import { Panel } from 'react-bootstrap';
 
-class TopicTemplate extends React.Component {
-  constructor(props) {
-    super(props);
-
-    const data = this.props.data;
-    this.suffix = '';
-    if (data.override) {
-      this.suffix = '**';
-    }
+const TopicTemplate = (props) => {
+  const data = props.data;
+  let suffix = '';
+  if (data.override) {
+    suffix = '**';
   }
-
-  render() {
-    const name = this.props.name;
-    return (
-      <Panel id={name} key={name}>
-        <Panel.Heading>
-          <ScrollableAnchor id={name}>
-            <Panel.Title componentClass="h3">
-              <a href={`#${name}`}>{name}{this.suffix}</a>
-            </Panel.Title>
-          </ScrollableAnchor>
-        </Panel.Heading>
-        <Panel.Body>{this.props.data.rendered}</Panel.Body>
-      </Panel>
-    );
-  }
-}
+  const name = props.name;
+  const text = props.data.rendered || props.data.text;
+  return (
+    <Panel id={name} key={name}>
+      <Panel.Heading>
+        <ScrollableAnchor id={name}>
+          <Panel.Title componentClass="h3">
+            <a href={`#${name}`}>{name}{suffix}</a>
+          </Panel.Title>
+        </ScrollableAnchor>
+      </Panel.Heading>
+      <Panel.Body>{text}</Panel.Body>
+    </Panel>
+  );
+};
 
 TopicTemplate.propTypes = {
   data: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types

--- a/client/src/Components/TopicDetail/TopicTemplates.js
+++ b/client/src/Components/TopicDetail/TopicTemplates.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TopicTemplate from './TopicTemplate';
+
+const TopicTemplates = (props) => {
+  const templates = props.templates;
+  const templateNames = Object.keys(templates);
+  const topicTemplates = templateNames.map((templateName) => {
+    const data = templates[templateName];
+    return <TopicTemplate key={templateName} name={templateName} data={data} />;
+  });
+  return <div>{topicTemplates}</div>;
+};
+
+TopicTemplates.propTypes = {
+  templates: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+};
+
+TopicTemplates.defaultProps = {
+  templates: {},
+};
+
+export default TopicTemplates;

--- a/client/src/Components/TriggerList/TriggerListItem.js
+++ b/client/src/Components/TriggerList/TriggerListItem.js
@@ -33,7 +33,12 @@ const TriggerListItem = (props) => {
           </Col>
           <Col md={8}>{getResponseFromTrigger(trigger)}</Col>
           <Col md={1}>
-            <ContentfulLink bsStyle="link" bsSize="xsmall" entryId={trigger.id} />
+            <ContentfulLink
+              bsStyle="link"
+              bsSize="xsmall"
+              entryId={trigger.id}
+              displayRefresh={false}
+            />
           </Col>
         </Row>
       </ScrollableAnchor>

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -35,6 +35,6 @@ module.exports.getTopics = function (query) {
   return executeGet('topics', query);
 };
 
-module.exports.getTopicById = function (topicId) {
-  return executeGet(`topics/${topicId}`);
+module.exports.getTopicById = function (topicId, query) {
+  return executeGet(`topics/${topicId}`, query);
 };

--- a/lib/gambit-conversations.js
+++ b/lib/gambit-conversations.js
@@ -54,7 +54,7 @@ module.exports.getBroadcasts = function (query) {
     .then(res => res.body);
 };
 
-module.exports.getBroadcastById = function (broadcastId) {
-  return executeGet(`v2/broadcasts/${broadcastId}`)
+module.exports.getBroadcastById = function (broadcastId, query) {
+  return executeGet(`v2/broadcasts/${broadcastId}`, query)
     .then(res => res.body);
 };

--- a/routes/api.js
+++ b/routes/api.js
@@ -16,7 +16,7 @@ router.get('/broadcasts', (req, res) => {
 });
 
 router.get('/broadcasts/:id', (req, res) => {
-  conversations.getBroadcastById(req.params.id)
+  conversations.getBroadcastById(req.params.id, req.query)
     .then(apiRes => res.send(apiRes))
     .catch(err => helpers.sendResponseForError(res, err));
 });
@@ -58,7 +58,7 @@ router.get('/topics', (req, res) => {
 });
 
 router.get('/topics/:id', (req, res) => {
-  campaigns.getTopicById(req.params.id)
+  campaigns.getTopicById(req.params.id, req.query)
     .then(apiRes => res.send(apiRes))
     .catch(err => helpers.sendResponseForError(res, err));
 });


### PR DESCRIPTION
Front-end updates for https://github.com/DoSomething/gambit-campaigns/pull/1064

* Adds a cache clear button to allow manually flushing the redis cache for a broadcast or topic

* Renders templates for a broadcast if they exist.

    * Refactors the `TopicDetail/TopicTemplate` component as`TemplateList` and `TemplateListItem` 