### PR TITLE
Clear Rivescript cache [pr]

### DIFF
--- a/client/src/Components/TriggerList/TriggerListContainer.js
+++ b/client/src/Components/TriggerList/TriggerListContainer.js
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Col, Grid, Row, Table } from 'react-bootstrap';
+import { Col, Glyphicon, Grid, Row, Table } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
+import queryString from 'query-string';
 import lodash from 'lodash';
 import HttpRequest from '../HttpRequest';
 import TriggerListItem from './TriggerListItem';
@@ -7,18 +9,28 @@ import helpers from '../../helpers';
 
 const TriggerListContainer = () => (
   <Grid>
-    <HttpRequest path={helpers.getRivescriptPath()}>
+    <HttpRequest
+      path={helpers.getRivescriptPath()}
+      query={queryString.parse(window.location.search)}
+    >
       {res => (
-        <Table striped><tbody>
-          <tr><th>
-            <Row key="header">
-              <Col md={3}>Trigger</Col>
-              <Col md={9}>Reply</Col>
-            </Row>
-          </th></tr>
-          {lodash.orderBy(res.data.topics.random, 'trigger')
-            .map(trigger => (<TriggerListItem trigger={trigger} />))}
-        </tbody></Table>
+        <div>
+          <p>
+            <Link to="?cache=false">
+              <Glyphicon glyph="refresh" /> Refresh
+            </Link>
+          </p>
+          <Table striped><tbody>
+            <tr><th>
+              <Row key="header">
+                <Col md={3}>Trigger</Col>
+                <Col md={9}>Reply</Col>
+              </Row>
+            </th></tr>
+            {lodash.orderBy(res.data.topics.random, 'trigger')
+              .map(trigger => (<TriggerListItem key={trigger.trigger} trigger={trigger} />))}
+          </tbody></Table>
+        </div>
       )}
     </HttpRequest>
   </Grid>

--- a/client/src/Components/TriggerList/TriggerListContainer.js
+++ b/client/src/Components/TriggerList/TriggerListContainer.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Col, Glyphicon, Grid, Row, Table } from 'react-bootstrap';
-import { Link } from 'react-router-dom';
+import { Button, ButtonToolbar, Col, Glyphicon, Grid, Panel, Row, Table } from 'react-bootstrap';
 import queryString from 'query-string';
 import lodash from 'lodash';
 import HttpRequest from '../HttpRequest';
@@ -13,25 +12,33 @@ const TriggerListContainer = () => (
       path={helpers.getRivescriptPath()}
       query={queryString.parse(window.location.search)}
     >
-      {res => (
-        <div>
-          <p>
-            <Link to="?cache=false">
-              <Glyphicon glyph="refresh" /> Refresh
-            </Link>
-          </p>
-          <Table striped><tbody>
-            <tr><th>
-              <Row key="header">
-                <Col md={3}>Trigger</Col>
-                <Col md={9}>Reply</Col>
-              </Row>
-            </th></tr>
-            {lodash.orderBy(res.data.topics.random, 'trigger')
-              .map(trigger => (<TriggerListItem key={trigger.trigger} trigger={trigger} />))}
-          </tbody></Table>
-        </div>
-      )}
+      {(res) => {
+        const rows = lodash.orderBy(res.data.topics.random, 'trigger')
+          .map(trigger => (<TriggerListItem key={trigger.trigger} trigger={trigger} />));
+        return (
+          <div>
+            <Panel>
+              <Panel.Body>
+                <p>Found <strong>{rows.length}</strong> triggers loaded.</p>
+                <ButtonToolbar>
+                  <Button type="reset" href="?cache=false" bsSize="small">
+                    <Glyphicon glyph="refresh" />
+                  </Button>
+                </ButtonToolbar>
+              </Panel.Body>
+            </Panel>
+            <Table striped><tbody>
+              <tr><th>
+                <Row key="header">
+                  <Col md={3}>Trigger</Col>
+                  <Col md={9}>Reply</Col>
+                </Row>
+              </th></tr>
+              {rows}
+            </tbody></Table>
+          </div>
+        );
+      }}
     </HttpRequest>
   </Grid>
 );

--- a/client/src/Components/TriggerList/TriggerListContainer.js
+++ b/client/src/Components/TriggerList/TriggerListContainer.js
@@ -1,68 +1,27 @@
 import React from 'react';
-import { Col, Grid, Panel, Row, Table } from 'react-bootstrap';
+import { Col, Grid, Row, Table } from 'react-bootstrap';
 import lodash from 'lodash';
 import HttpRequest from '../HttpRequest';
 import TriggerListItem from './TriggerListItem';
 import helpers from '../../helpers';
 
-const brainUrl = 'https://github.com/DoSomething/gambit-conversations/blob/master/brain';
-const ctlUrl = 'https://www.crisistextline.org';
-const standardsUrl = 'https://support.twilio.com/hc/en-us/articles/223182208-Industry-standards-for-U-S-short-code-HELP-and-STOP';
-
-function renderList(triggers, responseLabel = 'Reply') {
-  return (
-    <Table striped><tbody>
-      <tr><th>
-        <Row key="header">
-          <Col md={3}>Trigger</Col>
-          <Col md={9}>{responseLabel}</Col>
-        </Row>
-      </th></tr>
-      {triggers.map(trigger => <TriggerListItem key={trigger.id} trigger={trigger} />)}
-    </tbody></Table>
-  );
-}
-
 const TriggerListContainer = () => (
   <Grid>
-    <HttpRequest path={helpers.getDefaultTopicTriggersPath()}>
-      {(triggers) => {
-        const sortedByTrigger = lodash.sortBy(triggers, trigger => trigger.trigger);
-        const triggersByType = lodash.groupBy(sortedByTrigger, (trigger) => {
-          if (trigger.topicId) {
-            return 'topic';
-          }
-          return 'random';
-        });
-        /* eslint-disable max-len */
-        return (
-          <div>
-            <Panel>
-              <Panel.Body>
-                <p>There are <strong>{triggers.length}</strong> triggers published in Contentful, used to change topic, or send a quick reply.</p>
-                <p>They are loaded in addition to the <a href={brainUrl}>Rivescript hardcoded in Gambit</a>, which handles:</p>
-                <ul>
-                  <li>
-                    <a href={standardsUrl}>Industry standard INFO requests</a> (e.g. INFO, HELP)
-                  </li>
-                  <li>Subscription update requests (e.g. JOIN, STOP, UNSUBSCRIBE, LESS)</li>
-                  <li>Support requests (e.g. QUESTION)</li>
-                  <li>Crisis messages (when we prompt to message <a href={ctlUrl}>CTL</a>)</li>
-                </ul>
-              </Panel.Body>
-            </Panel>
-            <h3>Campaign triggers</h3>
-            <p>Count: <strong>{triggersByType.topic.length}</strong></p>
-            {renderList(triggersByType.topic, 'Topic')}
-            <h3>Quick replies</h3>
-            <p>Count: <strong>{triggersByType.random.length}</strong></p>
-            {renderList(triggersByType.random)}
-          </div>
-        );
-      }}
+    <HttpRequest path={helpers.getRivescriptPath()}>
+      {res => (
+        <Table striped><tbody>
+          <tr><th>
+            <Row key="header">
+              <Col md={3}>Trigger</Col>
+              <Col md={9}>Reply</Col>
+            </Row>
+          </th></tr>
+          {lodash.orderBy(res.data.topics.random, 'trigger')
+            .map(trigger => (<TriggerListItem trigger={trigger} />))}
+        </tbody></Table>
+      )}
     </HttpRequest>
   </Grid>
 );
-/* eslint-enable max-len */
 
 export default TriggerListContainer;

--- a/client/src/Components/TriggerList/TriggerListItem.js
+++ b/client/src/Components/TriggerList/TriggerListItem.js
@@ -3,21 +3,22 @@ import { Col, Row } from 'react-bootstrap';
 import ScrollableAnchor from 'react-scrollable-anchor';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import ContentfulLink from '../ContentfulLink';
 
 /**
  * @param {Object} trigger
  * @return {String}
  */
 function getResponseFromTrigger(trigger) {
-  if (trigger.topic) {
-    const url = `/topics/${trigger.topic.id}`;
-    return <Link to={url}>{trigger.topic.name}</Link>;
-  }
   if (trigger.redirect) {
     return <a href={`#${encodeURIComponent(trigger.redirect)}`}>{`@ ${trigger.redirect}`}</a>;
   }
-  return trigger.reply;
+  const reply = trigger.reply[0];
+  if (reply.includes('changeTopic')) {
+    const topicChangeCommand = reply.replace(/{(.*)}/, '$1').split('=');
+    const topicId = topicChangeCommand[1];
+    return <Link to={`/topics/${topicId}`}>{topicId}</Link>;
+  }
+  return trigger.reply[0];
 }
 
 const TriggerListItem = (props) => {
@@ -32,14 +33,6 @@ const TriggerListItem = (props) => {
             <a href={`#${anchor}`}><strong>{triggerText}</strong></a>
           </Col>
           <Col md={8}>{getResponseFromTrigger(trigger)}</Col>
-          <Col md={1}>
-            <ContentfulLink
-              bsStyle="link"
-              bsSize="xsmall"
-              entryId={trigger.id}
-              displayRefresh={false}
-            />
-          </Col>
         </Row>
       </ScrollableAnchor>
     </td></tr>

--- a/client/src/Components/TriggerList/TriggerListItem.js
+++ b/client/src/Components/TriggerList/TriggerListItem.js
@@ -18,7 +18,7 @@ function getResponseFromTrigger(trigger) {
     const topicId = topicChangeCommand[1];
     return <Link to={`/topics/${topicId}`}>{topicId}</Link>;
   }
-  return trigger.reply[0];
+  return reply;
 }
 
 const TriggerListItem = (props) => {

--- a/client/src/helpers.js
+++ b/client/src/helpers.js
@@ -114,6 +114,9 @@ module.exports = {
   getMessagesPath: function getMessagesPath() {
     return 'messages';
   },
+  getRivescriptPath: function getRivescriptPath() {
+    return 'rivescript';
+  },
   getTopicDescription,
   getTopicsPath: function getTopicsPath() {
     return 'topics';

--- a/lib/gambit-conversations.js
+++ b/lib/gambit-conversations.js
@@ -58,3 +58,8 @@ module.exports.getBroadcastById = function (broadcastId, query) {
   return executeGet(`v2/broadcasts/${broadcastId}`, query)
     .then(res => res.body);
 };
+
+module.exports.getRivescript = function (query) {
+  return executeGet('v2/rivescript', query)
+    .then(res => res.body);
+};

--- a/routes/api.js
+++ b/routes/api.js
@@ -51,6 +51,12 @@ router.get('/messages', (req, res) => {
     .catch(err => helpers.sendResponseForError(res, err));
 });
 
+router.get('/rivescript', (req, res) => {
+  conversations.getRivescript(req.query)
+    .then(apiRes => res.send(apiRes))
+    .catch(err => helpers.sendResponseForError(res, err));
+});
+
 router.get('/topics', (req, res) => {
   campaigns.getTopics(req.query)
     .then(apiRes => res.send(apiRes))


### PR DESCRIPTION
Refactors the TriggerList to query the Conversations rivescript endpoint, and trigger a Rivescript cache clear via query string.

NOTE: While testing this, I discovered a bug in Conversation where a Rivescript cache clear doesn't wipe the bot's loaded replies first, instead it adds to the number of replies to sort. Fix to be added in Conversations

Other notes:

* Includes all Rivescript, so hardcoded triggers for compliance, subscription status, and/or crisis messaging are visible

* Removes the topic title and campaign info from the reply list for now, as we're no longer sourcing the list from a `GET /defaultTopicTriggers` request. A future PR can add a query this endpoint to add the info (or ideally, hit up some GraphQL to avoid re-inventing the wheel)


