### PR TITLE
Removes list of triggers on TopicDetail

### DIFF
--- a/client/src/Components/TopicDetail/TopicDetail.js
+++ b/client/src/Components/TopicDetail/TopicDetail.js
@@ -3,17 +3,10 @@ import { Panel, Grid, PageHeader } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import TemplateList from '../TemplateList/TemplateList';
 import ContentfulLink from '../ContentfulLink';
-import helpers from '../../helpers';
 
 const TopicDetail = (props) => {
   const topic = props.topic;
-  const html = helpers.getTopicDescription(topic);
-  const summary = (
-    <span
-      dangerouslySetInnerHTML={{ __html: html }} // eslint-disable-line react/no-danger
-    />
-  );
-
+  const campaignTitle = topic.campaign.title ? topic.campaign.title : '(None)';
   return (
     <Grid>
       <PageHeader>{topic.name}</PageHeader>
@@ -21,7 +14,7 @@ const TopicDetail = (props) => {
         <Panel.Body>
           <ContentfulLink entryId={topic.id} />
           <p>
-            <strong>Campaign</strong>: {topic.campaign.title}
+            <strong>Campaign</strong>: {campaignTitle}
           </p>
         </Panel.Body>
       </Panel>

--- a/client/src/Components/TopicDetail/TopicDetail.js
+++ b/client/src/Components/TopicDetail/TopicDetail.js
@@ -5,13 +5,6 @@ import TemplateList from '../TemplateList/TemplateList';
 import ContentfulLink from '../ContentfulLink';
 import helpers from '../../helpers';
 
-/**
- * @param {Object} topic
- */
-function getTriggers(topic) {
-  return <p><strong>Keywords:</strong> {topic.triggers.join(', ')}</p>;
-}
-
 const TopicDetail = (props) => {
   const topic = props.topic;
   const html = helpers.getTopicDescription(topic);
@@ -28,10 +21,8 @@ const TopicDetail = (props) => {
         <Panel.Body>
           <ContentfulLink entryId={topic.id} />
           <p>
-            This topic {summary}.
+            <strong>Campaign</strong>: {topic.campaign.title}
           </p>
-          {topic.triggers.length ? getTriggers(topic) : null}
-
         </Panel.Body>
       </Panel>
       <TemplateList templates={topic.templates} />

--- a/client/src/helpers.js
+++ b/client/src/helpers.js
@@ -27,26 +27,6 @@ function getContentfulUrlForEntryId(entryId) {
   return `https://app.contentful.com/spaces/owik07lyerdj/entries/${entryId}`;
 }
 
-function getTopicDescription(topic) {
-  if (!topic.campaign) {
-    return 'is hardcoded in Rivescript';
-  }
-  if (!topic.campaign.id) {
-    return 'sends an autoReply';
-  }
-
-  const campaign = topic.campaign;
-  let postInfo = '';
-  if (topic.type === 'textPostConfig') {
-    postInfo = ' and text posts';
-  } else if (topic.type === 'photoPostConfig') {
-    postInfo = ' and photo posts';
-  }
-  const campaignLink = `<a href="/campaigns/${campaign.id}">${campaign.title} (${campaign.id})</a>`;
-
-  return `creates signups${postInfo} for <strong>${campaignLink}</strong>`;
-}
-
 module.exports = {
   /**
    * Returns localhost API url for given path and query object.
@@ -89,7 +69,6 @@ module.exports = {
   getRivescriptPath: function getRivescriptPath() {
     return 'rivescript';
   },
-  getTopicDescription,
   getTopicsPath: function getTopicsPath() {
     return 'topics';
   },


### PR DESCRIPTION
Fixes errors per breaking changes in https://github.com/DoSomething/gambit-campaigns/pull/1094.

The way we'll render this list is by executing a `GET /defaultTopicTriggers` to find any keywords associated with the topic - but will add this in a future PR to keep things readable. Future PR will fix up the "keywords" section in the `CampaignList` component to render list of keywords (we'll also want to make these changes in Gambit Slack as well)