### PR TITLE
Hotfix viewing a topic broadcast from /topics/:id

### DIFF
--- a/client/src/Components/BroadcastDetail/BroadcastDetail.js
+++ b/client/src/Components/BroadcastDetail/BroadcastDetail.js
@@ -1,25 +1,17 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Col, PageHeader, Row, Table } from 'react-bootstrap';
+import { PageHeader, Table } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import TemplateList from '../TemplateList/TemplateList';
 import TemplateListItem from '../TemplateList/TemplateListItem';
 import ContentfulLink from '../ContentfulLink';
+import BroadcastWebhook from './BroadcastWebhook';
 
 const helpers = require('../../helpers');
 
 function percent(value, total) {
   const result = ((value / total) * 100).toFixed(1);
   return `${result}%`;
-}
-
-function renderRow(label, data) {
-  return (
-    <Row componentClass="div">
-      <Col componentClass="p" sm={2}><strong>{label}</strong></Col>
-      <Col sm={10}>{data}</Col>
-    </Row>
-  );
 }
 
 /**
@@ -101,9 +93,13 @@ function renderStatsHeader(data) {
  */
 function renderStats(broadcast) {
   const stats = broadcast.stats;
+  if (!stats) {
+    return null;
+  }
   const total = stats.inbound.total;
   return (
     <div>
+      <h2>Stats</h2>
       {renderStatsHeader(stats)}
       {total > 0 ? renderMacros(broadcast) : null}
     </div>
@@ -112,8 +108,6 @@ function renderStats(broadcast) {
 
 const BroadcastDetail = (props) => {
   const broadcast = props.broadcast;
-  broadcast.webhookBody = JSON.stringify(broadcast.webhook.body, null, 2);
-
   return (
     <div>
       <PageHeader>
@@ -122,11 +116,8 @@ const BroadcastDetail = (props) => {
       </PageHeader>
       <TemplateListItem name={broadcast.type} data={broadcast.message} />
       <TemplateList templates={broadcast.templates} />
-      <h2>Stats</h2>
       {renderStats(broadcast)}
-      <h2>Settings</h2>
-      {renderRow('URL', broadcast.webhook.url)}
-      {renderRow('Body', <pre><code>{broadcast.webhookBody}</code></pre>)}
+      {broadcast.webhook ? <BroadcastWebhook config={broadcast.webhook} /> : null}
     </div>
   );
 };

--- a/client/src/Components/BroadcastDetail/BroadcastWebhook.js
+++ b/client/src/Components/BroadcastDetail/BroadcastWebhook.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Panel } from 'react-bootstrap';
+
+const BroadcastWebhook = props => (
+  <Panel>
+    <Panel.Heading>
+      <Panel.Title toggle>Settings</Panel.Title>
+    </Panel.Heading>
+    <Panel.Collapse>
+      <Panel.Body>
+        <p>
+          <code>{props.config.url}</code>
+        </p>
+        <pre>
+          <code>{JSON.stringify(props.config.body, null, 2)}</code>
+        </pre>
+      </Panel.Body>
+    </Panel.Collapse>
+  </Panel>
+);
+
+BroadcastWebhook.propTypes = {
+  config: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+};
+
+export default BroadcastWebhook;

--- a/client/src/Components/TopicDetail/TopicDetail.js
+++ b/client/src/Components/TopicDetail/TopicDetail.js
@@ -6,7 +6,7 @@ import ContentfulLink from '../ContentfulLink';
 
 const TopicDetail = (props) => {
   const topic = props.topic;
-  const campaignTitle = topic.campaign.title ? topic.campaign.title : '(None)';
+  const campaignTitle = topic.campaign ? topic.campaign.title : '(None)';
   return (
     <Grid>
       <PageHeader>{topic.name}</PageHeader>

--- a/client/src/Components/TopicDetail/TopicDetailContainer.js
+++ b/client/src/Components/TopicDetail/TopicDetailContainer.js
@@ -3,8 +3,18 @@ import PropTypes from 'prop-types';
 import { Grid } from 'react-bootstrap';
 import queryString from 'query-string';
 import HttpRequest from '../HttpRequest';
+import BroadcastDetail from '../BroadcastDetail/BroadcastDetail';
 import TopicDetail from './TopicDetail';
 import helpers from '../../helpers';
+
+function isBroadcast(type) {
+  const topicBroadcastTypes = [
+    'askSubscriptionStatus',
+    'askVotingPlanStatus',
+    'askYesNo',
+  ];
+  return topicBroadcastTypes.includes(type);
+}
 
 const TopicDetailContainer = props => (
   <Grid>
@@ -12,7 +22,12 @@ const TopicDetailContainer = props => (
       path={helpers.getTopicByIdPath(props.match.params.topicId)}
       query={queryString.parse(window.location.search)}
     >
-      {res => <TopicDetail topic={res} />}
+      {(res) => {
+        if (isBroadcast(res.type)) {
+          return <BroadcastDetail broadcast={res} />;
+        }
+        return <TopicDetail topic={res} />;
+      }}
     </HttpRequest>
   </Grid>
 );


### PR DESCRIPTION
Viewing a topic broadcasts like an `askVotingPlanStatus` breaks when viewing as a `TopicDetail`, which can happen by clicking on the topic link within a `MessageList` -- This is a hotfix by returning the `BroadcastDetail` component instead of `TopicDetail` component when viewing the broadcast at `/topics/:id`.

Ideally our`MessageList` needs to know more info about each topic, so it can return the topic title instead of the id, and also link the to `/broadcasts/:id` instead of `/topics/:id` to access the stats and webhook settings.