### PR TITLE
Restore clearing Rivescript cache

### DIFF
--- a/client/src/Components/AdminDashboard/AdminDashboard.js
+++ b/client/src/Components/AdminDashboard/AdminDashboard.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Button, ButtonToolbar, Col, Glyphicon, Grid, Panel, Row, Table } from 'react-bootstrap';
+import lodash from 'lodash';
+import queryString from 'query-string';
+
+import HttpRequest from '../HttpRequest';
+import helpers from '../../helpers';
+
+const AdminDashboard = () => (
+  <Grid>
+    <HttpRequest
+      path={helpers.getRivescriptPath()}
+      query={queryString.parse(window.location.search)}
+    >
+      {(res) => {
+        const rows = lodash.orderBy(res.data.topics.random, 'trigger')
+          .map((trigger) => {
+            const desc = trigger.reply.length ? trigger.reply : `@ ${trigger.redirect}`;
+            return (
+              <Row componentClass="tr" key={trigger.trigger}>
+                <Col componentClass="td"><strong>{trigger.trigger}</strong></Col>
+                <Col componentClass="td">{desc}</Col>
+              </Row>
+            );
+          });
+
+        return (
+          <div>
+            <Panel>
+              <Panel.Body>
+                <p>Found <strong>{rows.length}</strong> triggers loaded.</p>
+                <ButtonToolbar>
+                  <Button type="reset" href="?cache=false" bsSize="small">
+                    <Glyphicon glyph="refresh" />
+                  </Button>
+                </ButtonToolbar>
+              </Panel.Body>
+            </Panel>
+            <Table striped><tbody>
+              <Row componentClass="tr" key="header">
+                <Col componentClass="td" md={3}><strong>Trigger</strong></Col>
+                <Col componentClass="td" md={9}><strong>Reply</strong></Col>
+              </Row>
+              {rows}
+            </tbody></Table>
+          </div>
+        );
+      }}
+    </HttpRequest>
+  </Grid>
+);
+
+
+export default AdminDashboard;

--- a/client/src/Components/Header.js
+++ b/client/src/Components/Header.js
@@ -22,9 +22,6 @@ class Header extends React.Component {
           <NavItem active={activeCampaigns} eventKey={2} href="/campaigns">
             Campaigns
           </NavItem>
-          <NavItem active={pathname.includes('triggers')} eventKey={3} href="/triggers">
-            Triggers
-          </NavItem>
           <NavItem active={pathname.includes('broadcasts')} eventKey={4} href="/broadcasts">
             Broadcasts
           </NavItem>
@@ -32,6 +29,11 @@ class Header extends React.Component {
         <Navbar.Form pullRight>
           <ConversationSearchForm />
         </Navbar.Form>
+        <Nav pullRight>
+          <NavItem active={pathname.includes('triggers')} eventKey={3} href="/triggers">
+            Admin
+          </NavItem>
+        </Nav>
       </Navbar>
     );
   }

--- a/client/src/Components/Main.js
+++ b/client/src/Components/Main.js
@@ -11,7 +11,7 @@ import BroadcastList from './BroadcastList/BroadcastListContainer';
 import BroadcastDetail from './BroadcastDetail/BroadcastDetailContainer';
 import BroadcastReplyList from './BroadcastDetail/BroadcastReplyList';
 import TopicDetail from './TopicDetail/TopicDetailContainer';
-import TriggerList from './TriggerList/TriggerListContainer';
+import AdminDashboard from './AdminDashboard/AdminDashboard';
 
 const Main = () => (
   <main>
@@ -25,7 +25,7 @@ const Main = () => (
       <Route path="/requests" component={Home} />
       <Route path="/topics/:topicId" component={TopicDetail} />
       <Route path="/topics" component={CampaignList} />
-      <Route path="/triggers" component={TriggerList} />
+      <Route path="/triggers" component={AdminDashboard} />
       <Route path="/users/:userId" component={UserDetail} />
       <Route path="/users" component={UserList} />
       <Route path="/" component={Home} />


### PR DESCRIPTION
#80 refactors the `TriggerList` component to query the `defaultTopicTriggers` endpoint, which is great because we get nested information about topics and campaigns. But it breaks the existing functionality on the `/triggers` page that was used to query the `rivescript` endpoint, and clear the Rivescript cache. This restores clearing Rivescript cache with old code from #80 in a WIP `AdminDashboard` component. 