### PR TITLE
Filter activity by source, type

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   extends: '@dosomething/eslint-config/nodejs/8.x',
+  parser: 'babel-eslint',
   parserOptions: {
     sourceType: 'module',
   },

--- a/client/src/Components/CampaignDashboard/CampaignDashboard.js
+++ b/client/src/Components/CampaignDashboard/CampaignDashboard.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Grid, PageHeader, Table } from 'react-bootstrap';
 import HttpRequest from '../HttpRequest';
-import ActiveCampaignWtithTriggers from './CampaignsWithTriggers/ActiveCampaignWithTriggers';
-import ClosedCampaignWtithTriggers from './CampaignsWithTriggers/ClosedCampaignWithTriggers';
+import ActiveCampaignWithTriggers from './CampaignsWithTriggers/ActiveCampaignWithTriggers';
+import ClosedCampaignWithTriggers from './CampaignsWithTriggers/ClosedCampaignWithTriggers';
 import WebSignupList from './WebSignupList';
 import helpers from '../../helpers';
 
@@ -22,7 +22,7 @@ const CampaignListContainer = () => (
             <Table>
               <tbody>
                 {Object.values(campaignsByStatus.active).map(campaign => (
-                  <ActiveCampaignWtithTriggers
+                  <ActiveCampaignWithTriggers
                     key={campaign.id}
                     campaign={campaign}
                   />))}
@@ -32,7 +32,7 @@ const CampaignListContainer = () => (
             <Table>
               <tbody>
                 {Object.values(campaignsByStatus.closed).map(campaign => (
-                  <ClosedCampaignWtithTriggers
+                  <ClosedCampaignWithTriggers
                     key={campaign.id}
                     campaign={campaign}
                   />))}

--- a/client/src/Components/CampaignDashboard/CampaignDashboard.js
+++ b/client/src/Components/CampaignDashboard/CampaignDashboard.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid, Row, Table } from 'react-bootstrap';
+import { Grid, PageHeader, Table } from 'react-bootstrap';
 import HttpRequest from '../HttpRequest';
 import ActiveCampaignWtithTriggers from './CampaignsWithTriggers/ActiveCampaignWithTriggers';
 import ClosedCampaignWtithTriggers from './CampaignsWithTriggers/ClosedCampaignWithTriggers';
@@ -10,41 +10,41 @@ const webSignupHelpText = 'Users who sign up for the following campaigns over we
 
 const CampaignListContainer = () => (
   <Grid>
-    <Row>
-      <h2>Keywords</h2>
-      <HttpRequest path={helpers.getDefaultTopicTriggersPath()}>
-        {(res) => {
-          const campaignsByStatus = helpers.getCampaignsByStatus(res);
-          return (
-            <div>
-              <h3>Active</h3>
-              <Table>
-                <tbody>
-                  {Object.values(campaignsByStatus.active).map(campaign => (
-                    <ActiveCampaignWtithTriggers
-                      key={campaign.id}
-                      campaign={campaign}
-                    />))}
-                </tbody>
-              </Table>
-              <h3>Closed</h3>
-              <Table>
-                <tbody>
-                  {Object.values(campaignsByStatus.closed).map(campaign => (
-                    <ClosedCampaignWtithTriggers
-                      key={campaign.id}
-                      campaign={campaign}
-                    />))}
-                </tbody>
-              </Table>
-            </div>
-          );
-        }}
-      </HttpRequest>
-      <h3>Web signup confirmations</h3>
-      <p>{webSignupHelpText}</p>
-      <WebSignupList />
-    </Row>
+    <PageHeader>
+      Campaigns
+    </PageHeader>
+    <HttpRequest path={helpers.getDefaultTopicTriggersPath()}>
+      {(res) => {
+        const campaignsByStatus = helpers.getCampaignsByStatus(res);
+        return (
+          <div>
+            <h3>Active keywords</h3>
+            <Table>
+              <tbody>
+                {Object.values(campaignsByStatus.active).map(campaign => (
+                  <ActiveCampaignWtithTriggers
+                    key={campaign.id}
+                    campaign={campaign}
+                  />))}
+              </tbody>
+            </Table>
+            <h3>Closed keywords</h3>
+            <Table>
+              <tbody>
+                {Object.values(campaignsByStatus.closed).map(campaign => (
+                  <ClosedCampaignWtithTriggers
+                    key={campaign.id}
+                    campaign={campaign}
+                  />))}
+              </tbody>
+            </Table>
+          </div>
+        );
+      }}
+    </HttpRequest>
+    <h3>Web signup confirmations</h3>
+    <p>{webSignupHelpText}</p>
+    <WebSignupList />
   </Grid>
 );
 

--- a/client/src/Components/CampaignDetail/CampaignDetail.js
+++ b/client/src/Components/CampaignDetail/CampaignDetail.js
@@ -12,9 +12,6 @@ const CampaignDetail = (props) => {
       <Panel>
         <Panel.Body>
           <p>
-            <strong>Tagline:</strong> {campaign.tagline}
-          </p>
-          <p>
             <strong>Status:</strong> {campaign.status}
           </p>
         </Panel.Body>

--- a/client/src/Components/CampaignDetail/CampaignDetail.js
+++ b/client/src/Components/CampaignDetail/CampaignDetail.js
@@ -8,7 +8,7 @@ const CampaignDetail = (props) => {
   const campaign = props.campaign;
   return (
     <div>
-      <PageHeader>{campaign.title}</PageHeader>
+      <PageHeader>{campaign.internalTitle}</PageHeader>
       <Panel>
         <Panel.Body>
           <p>

--- a/client/src/Components/CampaignLink.js
+++ b/client/src/Components/CampaignLink.js
@@ -10,7 +10,7 @@ const CampaignLink = (props) => {
     endsLabel = <small> - Ends <Moment format={'MM/DD/YY'}>{campaign.endDate}</Moment></small>;
   }
 
-  const label = <span><strong>{campaign.title}</strong> ({campaign.id}){endsLabel}</span>;
+  const label = <span><strong>{campaign.internalTitle}</strong> ({campaign.id}){endsLabel}</span>;
   if (props.linkDisabled === true) {
     return label;
   }

--- a/client/src/Components/DraftSubmissionList/DraftSubmissionListContainer.js
+++ b/client/src/Components/DraftSubmissionList/DraftSubmissionListContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Col, Grid, Row, Table } from 'react-bootstrap';
+import { Col, Grid, PageHeader, Row, Table } from 'react-bootstrap';
 import HttpRequest from '../HttpRequest';
 import DraftSubmissionListItem from './DraftSubmissionListItem';
 import helpers from '../../helpers';
@@ -8,6 +8,9 @@ const query = { populate: 'conversationId', sort: '-createdAt' };
 
 const DraftSubmissionListContainer = () => (
   <Grid>
+    <PageHeader>
+      Draft photo posts
+    </PageHeader>
     <HttpRequest path={helpers.getDraftSubmissionsPath()} query={query} description="drafts">
       {res => (
         <Table hover>

--- a/client/src/Components/ListForm.js
+++ b/client/src/Components/ListForm.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Form, FormControl, FormGroup } from 'react-bootstrap';
+import queryString from 'query-string';
+
+class ListForm extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { value: '' };
+
+    this.handleSourceChange = this.handleSourceChange.bind(this);
+  }
+  handleSourceChange(event) { // eslint-disable-line class-methods-use-this
+    const location = window.location;
+    const url = [location.protocol, '//', location.host, location.pathname].join('');
+    const clientQuery = queryString.parse(location.search);
+    const currentSource = clientQuery.source;
+    const selectedValue = event.target.value;
+
+    if (currentSource === selectedValue) {
+      return;
+    }
+    if (selectedValue === 'all') {
+      delete clientQuery.source;
+    } else {
+      clientQuery.source = selectedValue;
+    }
+    delete clientQuery.skip;
+
+    window.location = `${url}?${queryString.stringify(clientQuery)}`;
+  }
+  render() {
+    const clientQuery = queryString.parse(window.location.search);
+    return (
+      <Form inline>
+        <FormGroup controlId="listFilterForm">
+          <FormControl componentClass="select" placeholder="select" onChange={this.handleSourceChange} >
+            <option value="all" selected={!!clientQuery.source}>all</option>
+            <option value="sms" selected={clientQuery.source === 'sms'}>sms</option>
+          </FormControl>
+        </FormGroup>
+      </Form>
+    );
+  }
+}
+
+export default ListForm;
+

--- a/client/src/Components/ListForm.js
+++ b/client/src/Components/ListForm.js
@@ -7,9 +7,8 @@ import queryString from 'query-string';
  * @param {String} filterValue
  */
 function handleFilterChange(filterName, selectedFilterValue) {
-  const location = window.location;
-  const url = [location.protocol, '//', location.host, location.pathname].join('');
-  const clientQuery = queryString.parse(location.search);
+  const { protocol, host, pathname } = window.location;
+  const clientQuery = queryString.parse(window.location.search);
   const currentFilterValue = clientQuery[filterName];
 
   if (currentFilterValue === selectedFilterValue) {
@@ -20,28 +19,19 @@ function handleFilterChange(filterName, selectedFilterValue) {
   } else {
     clientQuery[filterName] = selectedFilterValue;
   }
+  // We reset skip parameter when switching filters, as pagination would be awkward UX to persist.
   delete clientQuery.skip;
 
-  window.location = `${url}?${queryString.stringify(clientQuery)}`;
+  window.location = `${protocol}//${host}${pathname}?${queryString.stringify(clientQuery)}`;
 }
 
 class ListForm extends React.Component {
-  constructor(props) {
-    super(props);
-    this.handleSourceChange = this.handleSourceChange.bind(this);
-    this.handleTypeChange = this.handleTypeChange.bind(this);
-  }
-  handleSourceChange(event) { // eslint-disable-line class-methods-use-this
-    handleFilterChange('source', event.target.value);
-  }
-  handleTypeChange(event) { // eslint-disable-line class-methods-use-this
-    handleFilterChange('type', event.target.value);
-  }
+  handleSourceChange = event => handleFilterChange('source', event.target.value);
+  handleTypeChange = event => handleFilterChange('type', event.target.value);
   render() {
     const clientQuery = queryString.parse(window.location.search);
-    let typeFilterFormControl = null;
-    if (window.location.pathname === '/posts') {
-      typeFilterFormControl = (
+    const typeFilterFormControl = window.location.pathname === '/posts'
+      ? (
         <FormControl
           componentClass="select"
           placeholder="select"
@@ -52,8 +42,8 @@ class ListForm extends React.Component {
           <option value="photo">photo</option>
           <option value="text">text</option>
         </FormControl>
-      );
-    }
+      )
+      : null;
     return (
       <Form inline>
         <FormGroup controlId="listFilterForm">
@@ -74,4 +64,3 @@ class ListForm extends React.Component {
 }
 
 export default ListForm;
-

--- a/client/src/Components/ListForm.js
+++ b/client/src/Components/ListForm.js
@@ -2,41 +2,71 @@ import React from 'react';
 import { Form, FormControl, FormGroup } from 'react-bootstrap';
 import queryString from 'query-string';
 
+/**
+ * @param {String} filterName
+ * @param {String} filterValue
+ */
+function handleFilterChange(filterName, selectedFilterValue) {
+  const location = window.location;
+  const url = [location.protocol, '//', location.host, location.pathname].join('');
+  const clientQuery = queryString.parse(location.search);
+  const currentFilterValue = clientQuery[filterName];
+
+  if (currentFilterValue === selectedFilterValue) {
+    return;
+  }
+  if (selectedFilterValue === 'all') {
+    delete clientQuery[filterName];
+  } else {
+    clientQuery[filterName] = selectedFilterValue;
+  }
+  delete clientQuery.skip;
+
+  window.location = `${url}?${queryString.stringify(clientQuery)}`;
+}
+
 class ListForm extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { value: '' };
-
     this.handleSourceChange = this.handleSourceChange.bind(this);
+    this.handleTypeChange = this.handleTypeChange.bind(this);
   }
   handleSourceChange(event) { // eslint-disable-line class-methods-use-this
-    const location = window.location;
-    const url = [location.protocol, '//', location.host, location.pathname].join('');
-    const clientQuery = queryString.parse(location.search);
-    const currentSource = clientQuery.source;
-    const selectedValue = event.target.value;
-
-    if (currentSource === selectedValue) {
-      return;
-    }
-    if (selectedValue === 'all') {
-      delete clientQuery.source;
-    } else {
-      clientQuery.source = selectedValue;
-    }
-    delete clientQuery.skip;
-
-    window.location = `${url}?${queryString.stringify(clientQuery)}`;
+    handleFilterChange('source', event.target.value);
+  }
+  handleTypeChange(event) { // eslint-disable-line class-methods-use-this
+    handleFilterChange('type', event.target.value);
   }
   render() {
     const clientQuery = queryString.parse(window.location.search);
+    let typeFilterFormControl = null;
+    if (window.location.pathname === '/posts') {
+      typeFilterFormControl = (
+        <FormControl
+          componentClass="select"
+          placeholder="select"
+          onChange={this.handleTypeChange}
+          defaultValue={clientQuery.type || 'all'}
+        >
+          <option value="all">all</option>
+          <option value="photo">photo</option>
+          <option value="text">text</option>
+        </FormControl>
+      );
+    }
     return (
       <Form inline>
         <FormGroup controlId="listFilterForm">
-          <FormControl componentClass="select" placeholder="select" onChange={this.handleSourceChange} >
-            <option value="all" selected={!!clientQuery.source}>all</option>
-            <option value="sms" selected={clientQuery.source === 'sms'}>sms</option>
-          </FormControl>
+          <FormControl
+            componentClass="select"
+            placeholder="select"
+            onChange={this.handleSourceChange}
+            defaultValue={clientQuery.source || 'all'}
+          >
+            <option value="all">all</option>
+            <option value="phoenix-next">phoenix-next</option>
+            <option value="sms">sms</option>
+          </FormControl> {typeFilterFormControl}
         </FormGroup>
       </Form>
     );

--- a/client/src/Components/ListPager.js
+++ b/client/src/Components/ListPager.js
@@ -1,23 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Pager } from 'react-bootstrap';
+import queryString from 'query-string';
 
 class ListPager extends React.Component {
   constructor(props) {
     super(props);
+
     const skipCount = this.props.skipCount;
     const pageSize = this.props.pageSize;
     const totalResultCount = this.props.totalResultCount;
     this.startNumber = skipCount + 1;
     this.endNumber = (this.startNumber + this.props.pageCount) - 1;
+
+    const clientQuery = queryString.parse(window.location.search);
+    delete clientQuery.skip;
+
     const location = window.location;
     const url = [location.protocol, '//', location.host, location.pathname].join('');
+
     if (skipCount) {
       const prevSkip = skipCount - pageSize;
-      this.prevUrl = `${url}?skip=${prevSkip}`;
+      this.prevUrl = `${url}?skip=${prevSkip}&${queryString.stringify(clientQuery)}`;
     }
     if (totalResultCount > pageSize && this.endNumber < totalResultCount) {
-      this.nextUrl = `${url}?skip=${skipCount + pageSize}`;
+      this.nextUrl = `${url}?skip=${skipCount + pageSize}&${queryString.stringify(clientQuery)}`;
     }
   }
   render() {

--- a/client/src/Components/PostList/PostListContainer.js
+++ b/client/src/Components/PostList/PostListContainer.js
@@ -14,16 +14,17 @@ import config from '../../config';
 function getPostsQuery() {
   // TODO: We want to include the signup here to permalink to Rogue, but it breaks things on QA.
   // @see https://www.pivotaltracker.com/n/projects/2019429/stories/158870350
-  const query = { orderBy: 'id,desc' };
+  const query = {};
   const clientQuery = queryString.parse(window.location.search);
-  const skipQueryParam = clientQuery.skip;
-  if (skipQueryParam) {
+  if (clientQuery.skip) {
     // Rogue API expects a page parameter for current page of results.
-    query.page = (skipQueryParam / config.resultsPageSize) + 1;
+    query.page = (clientQuery.skip / config.resultsPageSize) + 1;
   }
-  const typeQueryParam = clientQuery.type;
-  if (typeQueryParam) {
-    query['filter[type]'] = typeQueryParam;
+  if (clientQuery.source) {
+    query['filter[source]'] = clientQuery.source;
+  }
+  if (clientQuery.type) {
+    query['filter[type]'] = clientQuery.type;
   }
   return query;
 }

--- a/client/src/Components/PostList/PostListContainer.js
+++ b/client/src/Components/PostList/PostListContainer.js
@@ -17,7 +17,7 @@ import config from '../../config';
 const PostListContainer = () => (
   <Grid>
     <PageHeader>
-      <h1>Posts</h1>
+      Posts
       <ListForm />
     </PageHeader>
     <HttpRequest

--- a/client/src/Components/PostList/PostListContainer.js
+++ b/client/src/Components/PostList/PostListContainer.js
@@ -8,30 +8,13 @@ import Post from '../SignupList/SignupPost';
 import helpers from '../../helpers';
 import config from '../../config';
 
-/**
- * @return {Object}
- */
-function getPostsQuery() {
-  // TODO: We want to include the signup here to permalink to Rogue, but it breaks things on QA.
-  // @see https://www.pivotaltracker.com/n/projects/2019429/stories/158870350
-  const query = {};
-  const clientQuery = queryString.parse(window.location.search);
-  if (clientQuery.skip) {
-    // Rogue API expects a page parameter for current page of results.
-    query.page = (clientQuery.skip / config.resultsPageSize) + 1;
-  }
-  if (clientQuery.source) {
-    query['filter[source]'] = clientQuery.source;
-  }
-  if (clientQuery.type) {
-    query['filter[type]'] = clientQuery.type;
-  }
-  return query;
-}
-
 const PostListContainer = () => (
   <Grid>
-    <HttpRequest path={helpers.getPostsPath()} query={getPostsQuery()} description="posts">
+    <HttpRequest
+      path={helpers.getPostsPath()}
+      query={helpers.getCampaignActivityQuery(queryString.parse(window.location.search))}
+      description="posts"
+    >
       {res => (
         <Table hover>
           <tbody>

--- a/client/src/Components/PostList/PostListContainer.js
+++ b/client/src/Components/PostList/PostListContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Col, Grid, Row, Table } from 'react-bootstrap';
+import { Col, Form, FormControl, FormGroup, Grid, PageHeader, Row, Table } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import Moment from 'react-moment';
 import queryString from 'query-string';
@@ -8,8 +8,26 @@ import Post from '../SignupList/SignupPost';
 import helpers from '../../helpers';
 import config from '../../config';
 
+/**
+ * TODO: Once it stops throwing a 500 error, we want to include 'include=signup' in our
+ * campaignActivity query, but it breaks things on QA.
+ * @see https://www.pivotaltracker.com/n/projects/2019429/stories/158870350
+ */
 const PostListContainer = () => (
   <Grid>
+    <PageHeader>
+      <h1>Posts</h1>
+      <Form inline>
+        <FormGroup
+          controlId="formBasicText"
+        >
+          <FormControl componentClass="select" placeholder="select">
+            <option value="select">all</option>
+            <option value="sms">sms</option>
+          </FormControl>
+        </FormGroup>
+      </Form>
+    </PageHeader>
     <HttpRequest
       path={helpers.getPostsPath()}
       query={helpers.getCampaignActivityQuery(queryString.parse(window.location.search))}

--- a/client/src/Components/PostList/PostListContainer.js
+++ b/client/src/Components/PostList/PostListContainer.js
@@ -43,7 +43,9 @@ const PostListContainer = () => {
                     <Col md={3} componentClass="td">
                       <Link to={`/users/${post.northstar_id}`}>{post.northstar_id}</Link>
                     </Col>
-                    <Col omponentClass="td"><Post post={post} /></Col>
+                    <Col componentClass="td">
+                      <Post post={post} displayFooter={false} />
+                    </Col>
                   </Row>
                 );
               })}

--- a/client/src/Components/PostList/PostListContainer.js
+++ b/client/src/Components/PostList/PostListContainer.js
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Col, Form, FormControl, FormGroup, Grid, PageHeader, Row, Table } from 'react-bootstrap';
+import { Col, Grid, PageHeader, Row, Table } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import Moment from 'react-moment';
 import queryString from 'query-string';
 import HttpRequest from '../HttpRequest';
+import ListForm from '../ListForm';
 import Post from '../SignupList/SignupPost';
 import helpers from '../../helpers';
 import config from '../../config';
@@ -17,16 +18,7 @@ const PostListContainer = () => (
   <Grid>
     <PageHeader>
       <h1>Posts</h1>
-      <Form inline>
-        <FormGroup
-          controlId="formBasicText"
-        >
-          <FormControl componentClass="select" placeholder="select">
-            <option value="select">all</option>
-            <option value="sms">sms</option>
-          </FormControl>
-        </FormGroup>
-      </Form>
+      <ListForm />
     </PageHeader>
     <HttpRequest
       path={helpers.getPostsPath()}

--- a/client/src/Components/PostList/PostListContainer.js
+++ b/client/src/Components/PostList/PostListContainer.js
@@ -9,55 +9,50 @@ import Post from '../SignupList/SignupPost';
 import helpers from '../../helpers';
 import config from '../../config';
 
-/**
- * TODO: Once it stops throwing a 500 error, we want to include 'include=signup' in our
- * campaignActivity query, but it breaks things on QA.
- * @see https://www.pivotaltracker.com/n/projects/2019429/stories/158870350
- */
-const PostListContainer = () => (
-  <Grid>
-    <PageHeader>
-      Posts
-      <ListForm />
-    </PageHeader>
-    <HttpRequest
-      path={helpers.getPostsPath()}
-      query={helpers.getCampaignActivityQuery(queryString.parse(window.location.search))}
-      description="posts"
-    >
-      {res => (
-        <Table hover>
-          <tbody>
-            <Row componentClass="tr" key="header">
-              <Col md={3} componentClass="th">Created</Col>
-              <Col md={3} componentClass="th">User</Col>
-              <Col md={2} componentClass="th">Campaign</Col>
-              <Col md={6} componentClass="th" />
-            </Row>
-            {res.data.map((post) => {
-              const campaignId = post.signup ? post.signup.data.campaign_id : null;
-              return (
-                <Row componentClass="tr" key={post.id}>
-                  <Col md={3} componentClass="td">
-                    <a href={post.signupUrl}>
-                      <Moment format={config.dateFormat}>{post.created_at}</Moment>
-                    </a>
-                  </Col>
-                  <Col md={3} componentClass="td">
-                    <Link to={`/users/${post.northstar_id}`}>{post.northstar_id}</Link>
-                  </Col>
-                  <Col md={2} componentClass="td">
-                    <Link to={`/campaigns/${campaignId}`}>{campaignId}</Link>
-                  </Col>
-                  <Col md={6} componentClass="td"><Post post={post} /></Col>
-                </Row>
-              );
-            })}
-          </tbody>
-        </Table>
-      )}
-    </HttpRequest>
-  </Grid>
-);
+const PostListContainer = () => {
+  const query = { include: 'signup' };
+  return (
+    <Grid>
+      <PageHeader>
+        Posts
+        <ListForm />
+      </PageHeader>
+      <HttpRequest
+        path={helpers.getPostsPath()}
+        query={helpers.getCampaignActivityQuery(queryString.parse(window.location.search), query)}
+        description="posts"
+      >
+        {res => (
+          <Table hover>
+            <tbody>
+              {res.data.map((post) => {
+                const campaignId = post.signup ? post.signup.data.campaign_id : null;
+                return (
+                  <Row componentClass="tr" key={post.id}>
+                    <Col md={2} componentClass="td">
+                      <a href={post.signupUrl}>
+                        <Moment format={config.dateFormat}>{post.created_at}</Moment>
+                      </a>
+                    </Col>
+                    <Col md={2} componentClass="td">
+                      <Link to={`/campaigns/${campaignId}`}>{campaignId}</Link>
+                    </Col>
+                    <Col componentClass="td" md={2}>
+                      {post.source}
+                    </Col>
+                    <Col md={3} componentClass="td">
+                      <Link to={`/users/${post.northstar_id}`}>{post.northstar_id}</Link>
+                    </Col>
+                    <Col omponentClass="td"><Post post={post} /></Col>
+                  </Row>
+                );
+              })}
+            </tbody>
+          </Table>
+        )}
+      </HttpRequest>
+    </Grid>
+  );
+};
 
 export default PostListContainer;

--- a/client/src/Components/SignupList/SignupListContainer.js
+++ b/client/src/Components/SignupList/SignupListContainer.js
@@ -12,15 +12,14 @@ const SignupListContainer = ({ userId, displayFilters }) => {
   if (userId) {
     query['filter[northstar_id]'] = userId;
   }
-  let filters = null;
-  if (displayFilters) {
-    filters = (
+  const filters = displayFilters
+    ? (
       <PageHeader>
         Signups
         <ListForm />
       </PageHeader>
-    );
-  }
+    )
+    : null;
 
   return (
     <Grid>

--- a/client/src/Components/SignupList/SignupListContainer.js
+++ b/client/src/Components/SignupList/SignupListContainer.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Col, Form, FormControl, FormGroup, Grid, PageHeader, Row, Table } from 'react-bootstrap';
+import { Col, Grid, PageHeader, Row, Table } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
 import HttpRequest from '../HttpRequest';
+import ListForm from '../ListForm';
 import SignupListItem from './SignupListItem';
 import helpers from '../../helpers';
 
@@ -11,23 +12,13 @@ const SignupListContainer = ({ userId }) => {
   if (userId) {
     query['filter[northstar_id]'] = userId;
   }
-  const clientQuery = queryString.parse(window.location.search);
-  const isSourceSms = clientQuery.source === 'sms';
+
 
   return (
     <Grid>
-      <PageHeader> 
+      <PageHeader>
         <h1>Signups</h1>
-        <Form inline>
-          <FormGroup
-            controlId="formBasicText"
-          >
-            <FormControl componentClass="select" placeholder="select">
-              <option value="all" selected={!isSourceSms}>all</option>
-              <option value="sms" selected={isSourceSms}>sms</option>
-            </FormControl>
-          </FormGroup>
-        </Form>
+        <ListForm />
       </PageHeader>
       <HttpRequest
         path={helpers.getSignupsPath()}

--- a/client/src/Components/SignupList/SignupListContainer.js
+++ b/client/src/Components/SignupList/SignupListContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Col, Grid, PageHeader, Row, Table } from 'react-bootstrap';
+import { Grid, PageHeader, Table } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
 import HttpRequest from '../HttpRequest';
@@ -7,19 +7,24 @@ import ListForm from '../ListForm';
 import SignupListItem from './SignupListItem';
 import helpers from '../../helpers';
 
-const SignupListContainer = ({ userId }) => {
+const SignupListContainer = ({ userId, displayFilters }) => {
   const query = { include: 'posts', orderBy: 'id,desc' };
   if (userId) {
     query['filter[northstar_id]'] = userId;
   }
-
-
-  return (
-    <Grid>
+  let filters = null;
+  if (displayFilters) {
+    filters = (
       <PageHeader>
         Signups
         <ListForm />
       </PageHeader>
+    );
+  }
+
+  return (
+    <Grid>
+      {filters}
       <HttpRequest
         path={helpers.getSignupsPath()}
         query={helpers.getCampaignActivityQuery(queryString.parse(window.location.search), query)}
@@ -28,12 +33,6 @@ const SignupListContainer = ({ userId }) => {
         {res => (
           <Table hover>
             <tbody>
-              <Row componentClass="tr" key="header">
-                <Col md={3} componentClass="th">Created</Col>
-                <Col md={3} componentClass="th">User</Col>
-                <Col md={2} componentClass="th">Campaign</Col>
-                <Col md={6} componentClass="th" />
-              </Row>
               {res.data.map(signup => <SignupListItem signup={signup} key={signup.id} />)}
             </tbody>
           </Table>
@@ -45,10 +44,12 @@ const SignupListContainer = ({ userId }) => {
 
 SignupListContainer.propTypes = {
   userId: PropTypes.string,
+  displayFilters: PropTypes.bool,
 };
 
 SignupListContainer.defaultProps = {
   userId: null,
+  displayFilters: true,
 };
 
 export default SignupListContainer;

--- a/client/src/Components/SignupList/SignupListContainer.js
+++ b/client/src/Components/SignupList/SignupListContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Col, Grid, Row, Table } from 'react-bootstrap';
+import { Col, Form, FormControl, FormGroup, Grid, PageHeader, Row, Table } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
 import HttpRequest from '../HttpRequest';
@@ -11,9 +11,24 @@ const SignupListContainer = ({ userId }) => {
   if (userId) {
     query['filter[northstar_id]'] = userId;
   }
+  const clientQuery = queryString.parse(window.location.search);
+  const isSourceSms = clientQuery.source === 'sms';
 
   return (
     <Grid>
+      <PageHeader> 
+        <h1>Signups</h1>
+        <Form inline>
+          <FormGroup
+            controlId="formBasicText"
+          >
+            <FormControl componentClass="select" placeholder="select">
+              <option value="all" selected={!isSourceSms}>all</option>
+              <option value="sms" selected={isSourceSms}>sms</option>
+            </FormControl>
+          </FormGroup>
+        </Form>
+      </PageHeader>
       <HttpRequest
         path={helpers.getSignupsPath()}
         query={helpers.getCampaignActivityQuery(queryString.parse(window.location.search), query)}

--- a/client/src/Components/SignupList/SignupListContainer.js
+++ b/client/src/Components/SignupList/SignupListContainer.js
@@ -5,46 +5,37 @@ import queryString from 'query-string';
 import HttpRequest from '../HttpRequest';
 import SignupListItem from './SignupListItem';
 import helpers from '../../helpers';
-import config from '../../config';
 
-/**
- * @return {Object}
- */
-function getSignupsQuery(userId) {
+const SignupListContainer = ({ userId }) => {
   const query = { include: 'posts', orderBy: 'id,desc' };
   if (userId) {
     query['filter[northstar_id]'] = userId;
   }
-  const clientQuery = queryString.parse(window.location.search);
-  if (clientQuery.skip) {
-    // Rogue API expects a page parameter for current page of results.
-    query.page = (clientQuery.skip / config.resultsPageSize) + 1;
-  }
-  if (clientQuery.source) {
-    query['filter[source]'] = clientQuery.source;
-  }
-  return query;
-}
 
-const SignupListContainer = props => (
-  <Grid>
-    <HttpRequest path={helpers.getSignupsPath()} query={getSignupsQuery(props.userId)} description="signups">
-      {res => (
-        <Table hover>
-          <tbody>
-            <Row componentClass="tr" key="header">
-              <Col md={3} componentClass="th">Created</Col>
-              <Col md={3} componentClass="th">User</Col>
-              <Col md={2} componentClass="th">Campaign</Col>
-              <Col md={6} componentClass="th" />
-            </Row>
-            {res.data.map(signup => <SignupListItem signup={signup} key={signup.id} />)}
-          </tbody>
-        </Table>
-      )}
-    </HttpRequest>
-  </Grid>
-);
+  return (
+    <Grid>
+      <HttpRequest
+        path={helpers.getSignupsPath()}
+        query={helpers.getCampaignActivityQuery(queryString.parse(window.location.search), query)}
+        description="signups"
+      >
+        {res => (
+          <Table hover>
+            <tbody>
+              <Row componentClass="tr" key="header">
+                <Col md={3} componentClass="th">Created</Col>
+                <Col md={3} componentClass="th">User</Col>
+                <Col md={2} componentClass="th">Campaign</Col>
+                <Col md={6} componentClass="th" />
+              </Row>
+              {res.data.map(signup => <SignupListItem signup={signup} key={signup.id} />)}
+            </tbody>
+          </Table>
+        )}
+      </HttpRequest>
+    </Grid>
+  );
+};
 
 SignupListContainer.propTypes = {
   userId: PropTypes.string,

--- a/client/src/Components/SignupList/SignupListContainer.js
+++ b/client/src/Components/SignupList/SignupListContainer.js
@@ -15,10 +15,13 @@ function getSignupsQuery(userId) {
   if (userId) {
     query['filter[northstar_id]'] = userId;
   }
-  const skipQueryParam = queryString.parse(window.location.search).skip;
-  if (skipQueryParam) {
+  const clientQuery = queryString.parse(window.location.search);
+  if (clientQuery.skip) {
     // Rogue API expects a page parameter for current page of results.
-    query.page = (skipQueryParam / config.resultsPageSize) + 1;
+    query.page = (clientQuery.skip / config.resultsPageSize) + 1;
+  }
+  if (clientQuery.source) {
+    query['filter[source]'] = clientQuery.source;
   }
   return query;
 }

--- a/client/src/Components/SignupList/SignupListContainer.js
+++ b/client/src/Components/SignupList/SignupListContainer.js
@@ -17,7 +17,7 @@ const SignupListContainer = ({ userId }) => {
   return (
     <Grid>
       <PageHeader>
-        <h1>Signups</h1>
+        Signups
         <ListForm />
       </PageHeader>
       <HttpRequest

--- a/client/src/Components/SignupList/SignupListItem.js
+++ b/client/src/Components/SignupList/SignupListItem.js
@@ -9,36 +9,37 @@ import config from '../../config';
 const SignupListItem = (props) => {
   const signup = props.signup;
   const campaignId = signup.campaign_id;
+  const posts = signup.posts.data;
   const userId = signup.northstar_id;
 
-  let whyParticipated = null;
-  if (signup.why_participated) {
-    whyParticipated = (
+  const whyParticipated = signup.why_participated
+    ? (
       <div>
         <p>
           Why participated: <strong>{signup.why_participated}</strong>
         </p>
       </div>
-    );
-  }
-  const posts = signup.posts.data;
-  let postsDesc = null;
-  if (posts.length) {
-    const postsPopover = (
-      <Popover>
-        {whyParticipated}
-        {posts.map(post => <SignupPost post={post} key={post.id} />)}
-      </Popover>
-    );
-    postsDesc = (
-      <OverlayTrigger trigger={['hover', 'focus']} placement="left" overlay={postsPopover}>
+    )
+    : null;
+
+  const postsDesc = posts.length
+    ? (
+      <OverlayTrigger
+        trigger={['hover', 'focus']}
+        placement="left"
+        overlay={(
+          <Popover>
+            {whyParticipated}
+            {posts.map(post => <SignupPost post={post} key={post.id} />)}
+          </Popover>
+        )}
+      >
         <Button bsStyle="link">
           {posts.length > 1 ? <span>{posts.length} posts</span> : <span>1 {posts[0].type}</span>}
         </Button>
       </OverlayTrigger>
-    );
-  }
-
+    )
+    : null;
 
   return (
     <Row componentClass="tr" key={signup.signup_id}>
@@ -58,7 +59,7 @@ const SignupListItem = (props) => {
         <Link to={`/users/${userId}`}>{userId}</Link>
       </Col>
       <Col componentClass="td">
-        {posts.length ? postsDesc : null}
+        {postsDesc}
       </Col>
     </Row>
   );

--- a/client/src/Components/SignupList/SignupListItem.js
+++ b/client/src/Components/SignupList/SignupListItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Col, Row } from 'react-bootstrap';
+import { Button, Col, OverlayTrigger, Popover, Row } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import Moment from 'react-moment';
 import PropTypes from 'prop-types';
@@ -11,9 +11,9 @@ const SignupListItem = (props) => {
   const campaignId = signup.campaign_id;
   const userId = signup.northstar_id;
 
-  let description = null;
+  let whyParticipated = null;
   if (signup.why_participated) {
-    description = (
+    whyParticipated = (
       <div>
         <p>
           Why participated: <strong>{signup.why_participated}</strong>
@@ -21,24 +21,44 @@ const SignupListItem = (props) => {
       </div>
     );
   }
+  const posts = signup.posts.data;
+  let postsDesc = null;
+  if (posts.length) {
+    const postsPopover = (
+      <Popover>
+        {whyParticipated}
+        {posts.map(post => <SignupPost post={post} key={post.id} />)}
+      </Popover>
+    );
+    postsDesc = (
+      <OverlayTrigger trigger={['hover', 'focus']} placement="left" overlay={postsPopover}>
+        <Button bsStyle="link">
+          {posts.length > 1 ? <span>{posts.length} posts</span> : <span>1 {posts[0].type}</span>}
+        </Button>
+      </OverlayTrigger>
+    );
+  }
+
+
   return (
     <Row componentClass="tr" key={signup.signup_id}>
-      <Col componentClass="td">
+      <Col componentClass="td" md={2}>
         <a href={signup.signupUrl}>
           <Moment format={config.dateFormat}>{signup.created_at}</Moment>
         </a>
-        <div>{signup.source}</div>
+      </Col>
+      <Col componentClass="td" md={2}>
+        <strong><a href={`/campaigns/${campaignId}`}>{campaignId}</a></strong>
+      </Col>
+      <Col componentClass="td" md={4}>
+        {signup.source}
         <div><small>{signup.details}</small></div>
       </Col>
-      <Col componentClass="td">
+      <Col componentClass="td" md={3}>
         <Link to={`/users/${userId}`}>{userId}</Link>
       </Col>
       <Col componentClass="td">
-        <strong><a href={`/campaigns/${campaignId}`}>{campaignId}</a></strong>
-      </Col>
-      <Col componentClass="td">
-        {description}
-        {signup.posts.data.map(post => <SignupPost post={post} key={post.id} />)}
+        {posts.length ? postsDesc : null}
       </Col>
     </Row>
   );

--- a/client/src/Components/SignupList/SignupPost.js
+++ b/client/src/Components/SignupList/SignupPost.js
@@ -32,22 +32,36 @@ const SignupPost = (props) => {
       </ListGroupItem>
     );
   }
-
+  let footer = null;
+  if (props.displayFooter) {
+    footer = (
+      <ListGroupItem>
+        <small>
+          Created <Moment format={'MM/DD/YY'}>{post.created_at}</Moment> {source}
+        </small>
+      </ListGroupItem>
+    );
+  }
   return (
     <ListGroup key={post.id}>
       {mediaGroupItem}
-      <ListGroupItem><strong>{post.media.text}</strong></ListGroupItem>
-      {quantityItem}
       <ListGroupItem>
-        {post.type} created <Moment format={'MM/DD/YY'}>{post.created_at}</Moment> {source}
-        <div>{postLabel(post.status)}</div>
+        {post.type === 'share-social' ? <span>shared {post.action}</span> : <strong>{post.media.text}</strong>}
       </ListGroupItem>
+      {quantityItem}
+      <ListGroupItem>{postLabel(post.status)}</ListGroupItem>
+      {footer}
     </ListGroup>
   );
 };
 
 SignupPost.propTypes = {
   post: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  displayFooter: PropTypes.boolean,
+};
+
+SignupPost.defaultProps = {
+  displayFooter: true,
 };
 
 export default SignupPost;

--- a/client/src/Components/SignupList/SignupPost.js
+++ b/client/src/Components/SignupList/SignupPost.js
@@ -20,7 +20,7 @@ const SignupPost = (props) => {
   if (post.media.url) {
     mediaGroupItem = (
       <ListGroupItem>
-        <Image src={post.media.url} height={200} />
+        <Image src={post.media.url} height={100} />
       </ListGroupItem>
     );
   }
@@ -32,16 +32,17 @@ const SignupPost = (props) => {
       </ListGroupItem>
     );
   }
-  let footer = null;
-  if (props.displayFooter) {
-    footer = (
+
+  const footer = props.displayFooter
+    ? (
       <ListGroupItem>
         <small>
           Created <Moment format={'MM/DD/YY'}>{post.created_at}</Moment> {source}
         </small>
       </ListGroupItem>
-    );
-  }
+    )
+    : null;
+
   return (
     <ListGroup key={post.id}>
       {mediaGroupItem}

--- a/client/src/Components/UserDetail/UserDetail.js
+++ b/client/src/Components/UserDetail/UserDetail.js
@@ -106,7 +106,7 @@ function tabs(user) {
       {conversationTab(smsConversationId, 'SMS', 0)}
       {slackTab}
       <Tab eventKey={numConversations + 1} title="Signups"><br />
-        <SignupList userId={user.id} />
+        <SignupList userId={user.id} displayFilters={false} />
       </Tab>
     </Tabs>
   );

--- a/client/src/helpers.js
+++ b/client/src/helpers.js
@@ -3,6 +3,26 @@ const querystring = require('querystring');
 const config = require('./config');
 
 /**
+ * @param {Object} clientQuery
+ * @param {Object} apiQuery
+ * @return {Object}
+ */
+function getCampaignActivityQuery(clientQuery, apiQuery = {}) {
+  const query = {};
+  if (clientQuery.skip) {
+    // Rogue API expects a page parameter for current page of results.
+    query.page = (clientQuery.skip / config.resultsPageSize) + 1;
+  }
+  if (clientQuery.source) {
+    query['filter[source]'] = clientQuery.source;
+  }
+  if (clientQuery.type) {
+    query['filter[type]'] = clientQuery.type;
+  }
+  return Object.assign(apiQuery, query);
+}
+
+/**
  * @param {Array} defaultTopicTriggers
  * @return {Object}
  */
@@ -69,6 +89,7 @@ module.exports = {
   getBroadcastsPath: function getBroadcastsPath() {
     return 'broadcasts';
   },
+  getCampaignActivityQuery,
   getCampaignByIdPath: function getCampaignByIdPath(campaignId) {
     return `${this.getCampaignsPath()}/${campaignId}`;
   },


### PR DESCRIPTION
Adds support to pass a `source` query parameter to filter signups or posts by source, e.g:
* https://gambit-admin.herokuapp.com/signups?source=sms


Adds support to pass a `type` query parameter by type, e.g:
* https://gambit-admin.herokuapp.com/signups?source=sms&type=text

Also adds helper for building the query string per https://github.com/DoSomething/gambit-admin/pull/85#discussion_r239550508.

Future PR hopes to add a form with select elements to add the query parameters.
