### PR TITLE
Adds check for signup.campaign

### DIFF
--- a/client/src/Components/SignupList/SignupListItem.js
+++ b/client/src/Components/SignupList/SignupListItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Col, OverlayTrigger, Popover, Row } from 'react-bootstrap';
+import { Col, Label, OverlayTrigger, Popover, Row } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import Moment from 'react-moment';
 import PropTypes from 'prop-types';
@@ -8,7 +8,6 @@ import config from '../../config';
 
 const SignupListItem = (props) => {
   const signup = props.signup;
-  const campaign = signup.campaign;
   const posts = signup.posts;
   const user = signup.user;
 
@@ -55,9 +54,18 @@ const SignupListItem = (props) => {
         </a>
       </Col>
       <Col componentClass="td" md={4}>
-        <a href={`/campaigns/${campaign.id}`}>
-          {campaign.internalTitle}
-        </a>
+        {signup.campaign
+          ? (
+            <a href={`/campaigns/${signup.campaign.id}`}>
+              {signup.campaign.internalTitle}
+             </a>
+            )
+          : (
+            <span>
+              Unknown campaign ID: <Label bsStyle="danger">{signup.campaignId}</Label>
+            </span>
+          )}
+
       </Col>
       {userCol}
       <Col componentClass="td">

--- a/client/src/graphql.js
+++ b/client/src/graphql.js
@@ -32,6 +32,7 @@ export const signupFieldsFragment = gql`
       id
       internalTitle
     }
+    campaignId,
     createdAt
     details
     id


### PR DESCRIPTION
Follow up to https://github.com/DoSomething/graphql/pull/31, this PR displays "Invalid campaign" message if a campaign is not found for a given signup's `campaignId` property. Refs [bug reported in Slack](https://dosomething.slack.com/archives/C0YGXUE01/p1547004263042700).