### PR TITLE
Fetch topic from GraphQL [pr]

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,6 +5,7 @@ import { createHttpLink } from 'apollo-link-http';
 import { setContext } from 'apollo-link-context';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { Button, Grid, Jumbotron } from 'react-bootstrap';
+import { IntrospectionFragmentMatcher } from 'apollo-cache-inmemory';
 
 import Header from './Components/Header';
 import Main from './Components/Main';
@@ -32,9 +33,12 @@ class App extends Component {
         const httpLink = createHttpLink({
           uri: session.config.services.graphQL.url,
         });
+        const fragmentMatcher = new IntrospectionFragmentMatcher({
+          introspectionQueryResultData: session.config.services.graphQL.schema
+        });
         const client = new ApolloClient({
           link: authLink.concat(httpLink),
-          cache: new InMemoryCache(),
+          cache: new InMemoryCache({ fragmentMatcher }),
         });
         this.setState({
           config: session.config,

--- a/client/src/Components/TemplateList/TemplateList.js
+++ b/client/src/Components/TemplateList/TemplateList.js
@@ -3,21 +3,15 @@ import PropTypes from 'prop-types';
 import TemplateListItem from './TemplateListItem';
 
 const TemplateList = (props) => {
-  const templates = props.templates;
-  const templateNames = Object.keys(templates);
-  const topicTemplates = templateNames.map((templateName) => {
-    const data = templates[templateName];
-    return <TemplateListItem key={templateName} name={templateName} data={data} />;
-  });
+  const topicTemplates = props.templates.map((templateName) => (
+    <TemplateListItem key={templateName} name={templateName} text={props.topic[templateName]} />
+  ));
   return <div>{topicTemplates}</div>;
 };
 
 TemplateList.propTypes = {
-  templates: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-};
-
-TemplateList.defaultProps = {
-  templates: {},
+  templates: PropTypes.array.isRequired,
+  topic: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 
 export default TemplateList;

--- a/client/src/Components/TemplateList/TemplateListItem.js
+++ b/client/src/Components/TemplateList/TemplateListItem.js
@@ -5,33 +5,27 @@ import { Link } from 'react-router-dom';
 import { Panel } from 'react-bootstrap';
 
 const TemplateListItem = (props) => {
-  const data = props.data;
-  let suffix = '';
-  if (data.override) {
-    suffix = '**';
-  }
   const name = props.name;
-  const text = props.data.rendered || props.data.text;
-  const topic = props.data.topic || {};
-  let footer = null;
-  if (topic.id) {
-    footer = (
+  const topic = props.topic || {};
+  const footer = topic.id
+    ? (
       <Panel.Footer>
         Changes topic to <Link to={`/topics/${topic.id}`}>{topic.name}</Link>
       </Panel.Footer>
-    );
-  }
+    )
+    : null;
+
   return (
     <Panel id={name} key={name}>
       <Panel.Heading>
         <ScrollableAnchor id={name}>
           <Panel.Title componentClass="h3">
-            <a href={`#${name}`}>{name}{suffix}</a>
+            <a href={`#${name}`}>{name}</a>
           </Panel.Title>
         </ScrollableAnchor>
       </Panel.Heading>
       <Panel.Body>
-        {text}
+        {props.text}
       </Panel.Body>
       {footer}
     </Panel>
@@ -39,8 +33,9 @@ const TemplateListItem = (props) => {
 };
 
 TemplateListItem.propTypes = {
-  data: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  topic: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   name: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
 };
 
 export default TemplateListItem;

--- a/client/src/Components/TopicDetail/TopicDetail.js
+++ b/client/src/Components/TopicDetail/TopicDetail.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Panel, Grid, PageHeader } from 'react-bootstrap';
-import PropTypes from 'prop-types'; 
+import PropTypes from 'prop-types';
 
 import TemplateList from '../TemplateList/TemplateList';
 import CampaignLink from '../CampaignLink';

--- a/client/src/Components/TopicDetail/TopicDetail.js
+++ b/client/src/Components/TopicDetail/TopicDetail.js
@@ -1,26 +1,71 @@
 import React from 'react';
 import { Panel, Grid, PageHeader } from 'react-bootstrap';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'; 
 
 import TemplateList from '../TemplateList/TemplateList';
 import CampaignLink from '../CampaignLink';
 import ContentfulLink from '../ContentfulLink';
+
+const getTemplates = (topic) => {
+  const type = topic.__typename;
+
+  if (type === 'AutoReplyTopic' || type === 'AutoReplySignupTopic') {
+    return (
+      <TemplateList
+        topic={topic}
+        templates={['autoReply']} 
+      />
+    );
+  }
+
+  if (type === 'TextPostTopic') {
+    return (
+      <TemplateList
+        topic={topic}
+        templates={['invalidText', 'completedTextPost']} 
+      />
+    );
+  }
+
+  if (type === 'PhotoPostTopic') {
+    return (
+      <TemplateList
+        topic={topic}
+        templates={[
+          'startPhotoPostAutoReply',
+          'askQuantity',
+          'invalidQuantity',
+          'askPhoto',
+          'invalidPhoto',
+          'askCaption',
+          'invalidCaption',
+          'askWhyParticipated',
+          'invalidWhyParticipated',
+          'completedPhotoPost',
+          'completedPhotoPostAutoReply',
+        ]} 
+      />
+    );
+  }
+
+  return null;
+}
 
 const TopicDetail = (props) => {
   const topic = props.topic;
   const campaignTitle = topic.campaign ? <CampaignLink campaign={topic.campaign} linkDisabled={false} /> : '(None)';
   return (
     <Grid>
-      <PageHeader>{topic.name}</PageHeader>
+      <PageHeader>{topic.name} <small><br />{topic.__typename}</small></PageHeader>
       <Panel>
         <Panel.Body>
           <ContentfulLink entryId={topic.id} />
           <p>
-            Campaign: {campaignTitle}
+            {campaignTitle}
           </p>
         </Panel.Body>
       </Panel>
-      <TemplateList templates={topic.templates} />
+      {getTemplates(topic)}
     </Grid>
   );
 };

--- a/client/src/Components/TopicDetail/TopicDetailContainer.js
+++ b/client/src/Components/TopicDetail/TopicDetailContainer.js
@@ -1,11 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid, PageHeader } from 'react-bootstrap';
-import queryString from 'query-string';
+import { Grid } from 'react-bootstrap';
 import GraphQLQuery from '../GraphQLQuery';
 import BroadcastDetail from '../BroadcastDetail/BroadcastDetail';
 import TopicDetail from './TopicDetail';
-import helpers from '../../helpers';
 import { getTopicByIdQuery } from '../../graphql';
 
 function isBroadcast(type) {
@@ -24,17 +22,9 @@ const TopicDetailContainer = props => (
         variables={{id: props.match.params.topicId }}
         displayPager={false}
       > 
-      {(res) => {
-        const topic = res.topic;
-        return (
-          <div>
-            <PageHeader>
-              {topic.name}
-            </PageHeader>
-            <p>{topic.__typename}</p>
-          </div>
-        );
-      }}
+      {res => isBroadcast(res.topic.type)
+        ? <BroadcastDetail topic={res.topic} />
+        : <TopicDetail topic={res.topic} />}
     </GraphQLQuery>
   </Grid>
 );

--- a/client/src/Components/TopicDetail/TopicDetailContainer.js
+++ b/client/src/Components/TopicDetail/TopicDetailContainer.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'react-bootstrap';
+import { Grid, PageHeader } from 'react-bootstrap';
 import queryString from 'query-string';
-import HttpRequest from '../HttpRequest';
+import GraphQLQuery from '../GraphQLQuery';
 import BroadcastDetail from '../BroadcastDetail/BroadcastDetail';
 import TopicDetail from './TopicDetail';
 import helpers from '../../helpers';
+import { getTopicByIdQuery } from '../../graphql';
 
 function isBroadcast(type) {
   const topicBroadcastTypes = [
@@ -18,17 +19,23 @@ function isBroadcast(type) {
 
 const TopicDetailContainer = props => (
   <Grid>
-    <HttpRequest
-      path={helpers.getTopicByIdPath(props.match.params.topicId)}
-      query={queryString.parse(window.location.search)}
-    >
+      <GraphQLQuery
+        query={getTopicByIdQuery}
+        variables={{id: props.match.params.topicId }}
+        displayPager={false}
+      > 
       {(res) => {
-        if (isBroadcast(res.type)) {
-          return <BroadcastDetail broadcast={res} />;
-        }
-        return <TopicDetail topic={res} />;
+        const topic = res.topic;
+        return (
+          <div>
+            <PageHeader>
+              {topic.name}
+            </PageHeader>
+            <p>{topic.__typename}</p>
+          </div>
+        );
       }}
-    </HttpRequest>
+    </GraphQLQuery>
   </Grid>
 );
 

--- a/client/src/graphql.js
+++ b/client/src/graphql.js
@@ -1,5 +1,84 @@
 import { gql } from 'apollo-boost';
 
+const campaignFields = `
+  campaign {
+    id
+    endDate
+    internalTitle
+  }
+`;
+
+const autoReplySignupCampaignFragment = gql`
+  fragment autoReplySignupCampaign on AutoReplySignupTopic {
+    ${campaignFields}
+  }
+`;
+
+const photoPostCampaignFragment = gql`
+  fragment photoPostCampaign on PhotoPostTopic {
+    ${campaignFields}
+  }
+`;
+
+const textPostCampaignFragment = gql`
+  fragment textPostCampaign on TextPostTopic {
+    ${campaignFields}
+  }
+`;
+
+export const getTopicByIdQuery = gql`
+  query getTopicById($id: String!) {
+    topic(id: $id) {
+      id
+      name
+      contentType
+      ... on AskYesNoBroadcastTopic {
+        invalidAskYesNoResponse
+        saidNo
+        saidNoTopic {
+          id
+        }
+        saidYes
+        saidYesTopic {
+          id
+          ...autoReplySignupCampaign
+          ...photoPostCampaign
+          ...textPostCampaign
+        }
+      }
+      ... on AutoReplySignupTopic {
+        ...autoReplySignupCampaign
+        autoReply
+      }
+      ... on AutoReplyTopic {
+        autoReply
+      }
+      ... on PhotoPostTopic {
+        ...photoPostCampaign
+        askCaption
+        askPhoto
+        askQuantity
+        askWhyParticipated
+        invalidCaption
+        invalidPhoto
+        invalidQuantity
+        invalidWhyParticipated
+        completedPhotoPost
+        completedPhotoPostAutoReply
+        startPhotoPostAutoReply
+      }
+      ... on TextPostTopic {
+        ...textPostCampaign
+        invalidText
+        completedTextPost
+      }
+    }
+  }
+  ${autoReplySignupCampaignFragment}
+  ${photoPostCampaignFragment}
+  ${textPostCampaignFragment}
+`;
+
 export const postFieldsFragment = gql`
   fragment postFields on Post {
     id

--- a/lib/graphql.js
+++ b/lib/graphql.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const superagent = require('superagent');
+const logger = require('heroku-logger');
+
+const config = require('../config/services').graphQL;
+
+/**
+ * Fetches GraphQL schema for Topic and Broadcast interfaces to use IntrospectionFragmentMatcher in
+ * our Apollo client.
+ *
+ * @see https://www.apollographql.com/docs/react/advanced/fragments.html#fragment-matcher
+ */
+module.exports.fetchSchema = async () => {
+  logger.info('Fetching GraphQL schema');
+
+  const res = await superagent.post(`${config.url}/graphql`)
+    .send({
+      variables: {},
+      query: `
+        {
+          __schema {
+            types {
+              kind
+              name
+              possibleTypes {
+                name
+              }
+            }
+          }
+        }
+      `,
+    });
+
+  const data = res.body.data;
+  // Filter out any type information unrelated to unions or interfaces.
+  const filteredData = data.__schema.types.filter(
+    type => type.possibleTypes !== null,
+  );
+  data.__schema.types = filteredData;
+  return data;
+}

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -10,7 +10,7 @@ const servicesConfig = require('../config/services');
 const authUrl = servicesConfig.northstar.url;
 const webUrl = appConfig.webUrl || appConfig.appUrl;
 
-module.exports = async () => {
+module.exports = async ({ schema }) => {
   const router = express.Router();
 
   // Wait until we discover OpenID Configuration.
@@ -57,6 +57,7 @@ module.exports = async () => {
         services: {
           graphQL: {
             url: servicesConfig.graphQL.url,
+            schema,
           },
         },
       },

--- a/server.js
+++ b/server.js
@@ -23,11 +23,13 @@ app.use(bodyParser.json());
 // parse application/x-www-form-urlencoded Content-Type
 app.use(bodyParser.urlencoded({ extended: true }));
 
-
 // Register routes & start it up!
 (async () => {
   /* eslint-disable global-require */
-  app.use(await require('./routes/auth')());
+  const graphql = require('./lib/graphql');
+  const schema = await graphql.fetchSchema();
+
+  app.use(await require('./routes/auth')({ schema }));
   app.use('/api', require('./routes/api'));
   /* eslint-enable */
 


### PR DESCRIPTION
Front-end updates per https://github.com/DoSomething/gambit-conversations/pull/461: 

* Fetches Topic detail from GraphQL

* Fetches GraphQL schema for Broadcast and Topic interfaces on app start, and exposes it in a `GET /auth/session` response, exposing to the client for InMemoryCache with IntrospectionFragmentMatcher

Note the cache clear button won't work anymore... ideally we'd like Contentful webhooks to clear the GraphQL and Gambit cache for an entry.