### PR TITLE
Fetch broadcast from GraphQL [pr]

### DIFF
--- a/client/src/Components/BroadcastDetail/BroadcastDetail.js
+++ b/client/src/Components/BroadcastDetail/BroadcastDetail.js
@@ -3,11 +3,8 @@ import { PageHeader } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import TemplateListItem from '../TemplateList/TemplateListItem';
 import ContentfulLink from '../ContentfulLink';
-import BroadcastStatsContainer from './BroadcastStats';
-import BroadcastWebhook from './BroadcastWebhook';
+import BroadcastStats from './BroadcastStatsContainer';
 import TopicTemplates from '../TopicDetail/TopicTemplates';
-
-const helpers = require('../../helpers');
 
 const BroadcastDetail = ({ broadcast }) => (
   <div>
@@ -17,6 +14,7 @@ const BroadcastDetail = ({ broadcast }) => (
     </PageHeader>
     <TemplateListItem name={broadcast.contentType} text={broadcast.text} />
     <TopicTemplates topic={broadcast} />
+    <BroadcastStats broadcastId={broadcast.id} />
   </div>
 );
 

--- a/client/src/Components/BroadcastDetail/BroadcastDetail.js
+++ b/client/src/Components/BroadcastDetail/BroadcastDetail.js
@@ -3,8 +3,9 @@ import { PageHeader } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import TemplateListItem from '../TemplateList/TemplateListItem';
 import ContentfulLink from '../ContentfulLink';
-import BroadcastStats from './BroadcastStats';
+import BroadcastStatsContainer from './BroadcastStats';
 import BroadcastWebhook from './BroadcastWebhook';
+import TopicTemplates from '../TopicDetail/TopicTemplates';
 
 const helpers = require('../../helpers');
 
@@ -12,11 +13,10 @@ const BroadcastDetail = ({ broadcast }) => (
   <div>
     <PageHeader>
       <ContentfulLink entryId={broadcast.id} />
-      {helpers.broadcastName(broadcast)}
+      {broadcast.name}
     </PageHeader>
     <TemplateListItem name={broadcast.contentType} text={broadcast.text} />
-    {broadcast.stats ? <BroadcastStats stats={broadcast.stats} /> : null}
-    {broadcast.webhook ? <BroadcastWebhook config={broadcast.webhook} /> : null}
+    <TopicTemplates topic={broadcast} />
   </div>
 );
 

--- a/client/src/Components/BroadcastDetail/BroadcastDetail.js
+++ b/client/src/Components/BroadcastDetail/BroadcastDetail.js
@@ -12,7 +12,11 @@ const BroadcastDetail = ({ broadcast }) => (
       <ContentfulLink entryId={broadcast.id} />
       {broadcast.name}
     </PageHeader>
-    <TemplateListItem name={broadcast.contentType} text={broadcast.text} />
+    <TemplateListItem
+      name={broadcast.contentType}
+      text={broadcast.text}
+      topic={broadcast.topic} 
+     />
     <TopicTemplates topic={broadcast} />
     <BroadcastStats broadcastId={broadcast.id} />
   </div>

--- a/client/src/Components/BroadcastDetail/BroadcastDetail.js
+++ b/client/src/Components/BroadcastDetail/BroadcastDetail.js
@@ -1,124 +1,24 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { PageHeader, Table } from 'react-bootstrap';
+import { PageHeader } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import TemplateListItem from '../TemplateList/TemplateListItem';
 import ContentfulLink from '../ContentfulLink';
+import BroadcastStats from './BroadcastStats';
 import BroadcastWebhook from './BroadcastWebhook';
 
 const helpers = require('../../helpers');
 
-function percent(value, total) {
-  const result = ((value / total) * 100).toFixed(1);
-  return `${result}%`;
-}
-
-/**
- * @param {string} label
- * @param {number} count
- */
-function MacroStats({ name, label, count, total }) {
-  let data = count;
-  let url = `${window.location.pathname}/${name}`;
-  if (!count) {
-    data = 0;
-    url = '#';
-  }
-  const rate = percent(data, total);
-
-  return (
-    <tr>
-      <td><Link to={url}>{label}</Link></td>
-      <td><Link to={url}>{data.toLocaleString()}</Link></td>
-      <td><Link to={url}>{rate}</Link></td>
-    </tr>
-  );
-}
-
-MacroStats.propTypes = {
-  name: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  count: PropTypes.number.isRequired,
-  total: PropTypes.number.isRequired,
-};
-
-/**
- * @param {object} broadcast
- */
-function renderMacros(broadcast) {
-  const stats = broadcast.stats;
-  const macros = stats.inbound.macros;
-  const totalReplyCount = stats.outbound.total;
-
-  const data = Object.keys(stats.inbound.macros).map((macro) => {
-    const currentMacroCount = macros[macro];
-    return (
-      <MacroStats
-        key={macro}
-        name={macro}
-        label={macro}
-        count={currentMacroCount}
-        total={totalReplyCount}
-      />
-    );
-  });
-
-  return (
-    <Table striped>
-      <tbody>
-        {data}
-      </tbody>
-    </Table>
-  );
-}
-
-function renderStatsHeader(data) {
-  const totalOutbound = data.outbound.total;
-  if (totalOutbound === 0) {
-    return <p>No messages found.</p>;
-  }
-  const totalInboundStr = <strong>{data.inbound.total.toLocaleString()}</strong>;
-  const totalOutboundStr = <strong>{totalOutbound.toLocaleString()}</strong>;
-  const rate = percent(data.inbound.total, totalOutbound);
-  return (
-    <h4>
-      Sent {totalOutboundStr} messages, received {totalInboundStr} responses. <small>{rate}</small>
-    </h4>
-  );
-}
-
-/**
- * @param {object} broadcast
- */
-function renderStats(broadcast) {
-  const stats = broadcast.stats;
-  if (!stats) {
-    return null;
-  }
-  const total = stats.inbound.total;
-  return (
-    <div>
-      <h2>Stats</h2>
-      {renderStatsHeader(stats)}
-      {total > 0 ? renderMacros(broadcast) : null}
-    </div>
-  );
-}
-
-const BroadcastDetail = (props) => {
-  const broadcast = props.broadcast;
-  return (
-    <div>
-      <PageHeader>
-        <ContentfulLink entryId={broadcast.id} />
-        {helpers.broadcastName(broadcast)}
-      </PageHeader>
-      <TemplateListItem name={broadcast.contentType} text={broadcast.text} />
-      {renderStats(broadcast)}
-      {broadcast.webhook ? <BroadcastWebhook config={broadcast.webhook} /> : null}
-    </div>
-  );
-};
+const BroadcastDetail = ({ broadcast }) => (
+  <div>
+    <PageHeader>
+      <ContentfulLink entryId={broadcast.id} />
+      {helpers.broadcastName(broadcast)}
+    </PageHeader>
+    <TemplateListItem name={broadcast.contentType} text={broadcast.text} />
+    {broadcast.stats ? <BroadcastStats stats={broadcast.stats} /> : null}
+    {broadcast.webhook ? <BroadcastWebhook config={broadcast.webhook} /> : null}
+  </div>
+);
 
 BroadcastDetail.propTypes = {
   broadcast: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types

--- a/client/src/Components/BroadcastDetail/BroadcastDetailContainer.js
+++ b/client/src/Components/BroadcastDetail/BroadcastDetailContainer.js
@@ -9,7 +9,7 @@ const BroadcastDetailContainer = props => (
   <Grid>
     <GraphQLQuery
       query={getBroadcastByIdQuery}
-      variables={{id: props.match.params.broadcastId }}
+      variables={{ id: props.match.params.broadcastId }}
       displayPager={false}
     > 
        {res => <BroadcastDetail broadcast={res.broadcast} />}
@@ -19,7 +19,7 @@ const BroadcastDetailContainer = props => (
 
 BroadcastDetailContainer.propTypes = {
   match: PropTypes.shape({
-    params: PropTypes.shape({ topicId: PropTypes.string.isRequired }).isRequired,
+    params: PropTypes.shape({ broadcastId: PropTypes.string.isRequired }).isRequired,
   }).isRequired,
 };
 

--- a/client/src/Components/BroadcastDetail/BroadcastDetailContainer.js
+++ b/client/src/Components/BroadcastDetail/BroadcastDetailContainer.js
@@ -1,25 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Grid } from 'react-bootstrap';
-import queryString from 'query-string';
-import HttpRequest from '../HttpRequest';
+import GraphQLQuery from '../GraphQLQuery';
 import BroadcastDetail from './BroadcastDetail';
-import helpers from '../../helpers';
+import { getBroadcastByIdQuery } from '../../graphql';
 
 const BroadcastDetailContainer = props => (
   <Grid>
-    <HttpRequest
-      path={helpers.getBroadcastByIdPath(props.match.params.broadcastId)}
-      query={queryString.parse(window.location.search)}
-    >
-      {res => <BroadcastDetail broadcast={res.data} />}
-    </HttpRequest>
+    <GraphQLQuery
+      query={getBroadcastByIdQuery}
+      variables={{id: props.match.params.broadcastId }}
+      displayPager={false}
+    > 
+       {res => <BroadcastDetail broadcast={res.broadcast} />}
+    </GraphQLQuery>
   </Grid>
 );
 
 BroadcastDetailContainer.propTypes = {
   match: PropTypes.shape({
-    params: PropTypes.shape({ broadcastId: PropTypes.string.isRequired }).isRequired,
+    params: PropTypes.shape({ topicId: PropTypes.string.isRequired }).isRequired,
   }).isRequired,
 };
 

--- a/client/src/Components/BroadcastDetail/BroadcastStats.js
+++ b/client/src/Components/BroadcastDetail/BroadcastStats.js
@@ -1,0 +1,98 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { Table } from 'react-bootstrap';
+
+function percent(value, total) {
+  const result = ((value / total) * 100).toFixed(1);
+  return `${result}%`;
+}
+
+/**
+ * @param {string} label
+ * @param {number} count
+ */
+function MacroStats({ name, label, count, total }) {
+  let data = count;
+  let url = `${window.location.pathname}/${name}`;
+  if (!count) {
+    data = 0;
+    url = '#';
+  }
+  const rate = percent(data, total);
+
+  return (
+    <tr>
+      <td><Link to={url}>{label}</Link></td>
+      <td><Link to={url}>{data.toLocaleString()}</Link></td>
+      <td><Link to={url}>{rate}</Link></td>
+    </tr>
+  );
+}
+
+MacroStats.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  count: PropTypes.number.isRequired,
+  total: PropTypes.number.isRequired,
+};
+
+/**
+ * @param {object} stats
+ */
+function renderMacros(stats) {
+  const macros = stats.inbound.macros;
+  const totalReplyCount = stats.outbound.total;
+
+  const data = Object.keys(stats.inbound.macros).map((macro) => {
+    const currentMacroCount = macros[macro];
+    return (
+      <MacroStats
+        key={macro}
+        name={macro}
+        label={macro}
+        count={currentMacroCount}
+        total={totalReplyCount}
+      />
+    );
+  });
+
+  return (
+    <Table striped>
+      <tbody>
+        {data}
+      </tbody>
+    </Table>
+  );
+}
+
+const BroadcastStats = ({ stats }) => {
+  const header = <h2>Stats</h2>;
+  const totalOutbound = stats.outbound.total;
+  if (totalOutbound === 0) {
+    return (
+      <div>
+        {header}
+        <p>No messages found.</p>
+      </div>
+    );
+  }
+  const totalInboundStr = <strong>{stats.inbound.total.toLocaleString()}</strong>;
+  const totalOutboundStr = <strong>{totalOutbound.toLocaleString()}</strong>;
+  const rate = percent(stats.inbound.total, totalOutbound);
+  return (
+    <div>
+      <h2>Stats</h2>
+      <h4>
+        Sent {totalOutboundStr} messages, received {totalInboundStr} responses. <small>{rate}</small>
+      </h4>
+      {totalOutbound > 0 ? renderMacros(stats) : null}
+    </div>
+  );
+};
+
+BroadcastStats.propTypes = {
+  stats: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+};
+
+export default BroadcastStats;

--- a/client/src/Components/BroadcastDetail/BroadcastStats.js
+++ b/client/src/Components/BroadcastDetail/BroadcastStats.js
@@ -3,96 +3,70 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { Table } from 'react-bootstrap';
 
-function percent(value, total) {
+/**
+ * @param {Number} value
+ * @param {Number} total
+ * @return {String}
+ */
+function formatPercentage(value, total) {
   const result = ((value / total) * 100).toFixed(1);
   return `${result}%`;
 }
 
-/**
- * @param {string} label
- * @param {number} count
- */
-function MacroStats({ name, label, count, total }) {
-  let data = count;
-  let url = `${window.location.pathname}/${name}`;
-  if (!count) {
-    data = 0;
-    url = '#';
-  }
-  const rate = percent(data, total);
-
-  return (
-    <tr>
-      <td><Link to={url}>{label}</Link></td>
-      <td><Link to={url}>{data.toLocaleString()}</Link></td>
-      <td><Link to={url}>{rate}</Link></td>
-    </tr>
-  );
-}
-
-MacroStats.propTypes = {
-  name: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  count: PropTypes.number.isRequired,
-  total: PropTypes.number.isRequired,
-};
-
-/**
- * @param {object} stats
- */
-function renderMacros(stats) {
-  const macros = stats.inbound.macros;
-  const totalReplyCount = stats.outbound.total;
-
-  const data = Object.keys(stats.inbound.macros).map((macro) => {
-    const currentMacroCount = macros[macro];
-    return (
-      <MacroStats
-        key={macro}
-        name={macro}
-        label={macro}
-        count={currentMacroCount}
-        total={totalReplyCount}
-      />
-    );
-  });
-
-  return (
-    <Table striped>
-      <tbody>
-        {data}
-      </tbody>
-    </Table>
-  );
-}
-
 const BroadcastStats = ({ stats }) => {
   const header = <h2>Stats</h2>;
-  const totalOutbound = stats.outbound.total;
-  if (totalOutbound === 0) {
+
+  if (stats.outbound.total === 0) {
     return (
       <div>
         {header}
-        <p>No messages found.</p>
+        <p>No outbound messages found.</p>
       </div>
     );
   }
-  const totalInboundStr = <strong>{stats.inbound.total.toLocaleString()}</strong>;
-  const totalOutboundStr = <strong>{totalOutbound.toLocaleString()}</strong>;
-  const rate = percent(stats.inbound.total, totalOutbound);
+
   return (
     <div>
-      <h2>Stats</h2>
+      {header}
       <h4>
-        Sent {totalOutboundStr} messages, received {totalInboundStr} responses. <small>{rate}</small>
+        Sent <strong>{stats.outbound.total.toLocaleString()}</strong> messages, received <strong>{stats.inbound.total.toLocaleString()}</strong> responses. <small>{formatPercentage(stats.inbound.total, stats.outbound.total)}</small>
       </h4>
-      {totalOutbound > 0 ? renderMacros(stats) : null}
+      <Table striped>
+        <tbody>
+          {Object.keys(stats.inbound.macros).sort().map((macro) => {
+            const currentMacroCount = stats.inbound.macros[macro];
+            const url = `${window.location.pathname}/${macro}`;
+            return (
+              <tr key={macro}>
+                <td>
+                  <Link to={url}>
+                    {macro}
+                  </Link>
+                </td>
+                <td>
+                  <Link to={url}>
+                    {currentMacroCount.toLocaleString()}
+                  </Link>
+                </td>
+                <td>
+                  <Link to={url}>
+                    {formatPercentage(currentMacroCount, stats.outbound.total)}
+                  </Link>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </Table>
     </div>
   );
 };
 
 BroadcastStats.propTypes = {
-  stats: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  stats: PropTypes.shape({
+    inbound: PropTypes.object,
+    outbound: PropTypes.object,
+  }).isRequired,
 };
 
 export default BroadcastStats;

--- a/client/src/Components/BroadcastDetail/BroadcastStatsContainer.js
+++ b/client/src/Components/BroadcastDetail/BroadcastStatsContainer.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Grid } from 'react-bootstrap';
 import HttpRequest from '../HttpRequest';
 import BroadcastStats from './BroadcastStats';
+import BroadcastWebhook from './BroadcastWebhook';
 import helpers from '../../helpers';
 
 const BroadcastStatsContainer = ({ broadcastId}) => (
@@ -10,7 +11,12 @@ const BroadcastStatsContainer = ({ broadcastId}) => (
     <HttpRequest
       path={helpers.getBroadcastByIdPath(broadcastId)}
     >
-      {res => <BroadcastStats stats={res.data.stats} />}
+      {res => (
+        <div>
+          <BroadcastStats stats={res.data.stats} />
+          <BroadcastWebhook config={res.data.webhook} />
+        </div>
+      )}
     </HttpRequest>
   </Grid>
 );

--- a/client/src/Components/BroadcastDetail/BroadcastStatsContainer.js
+++ b/client/src/Components/BroadcastDetail/BroadcastStatsContainer.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Grid } from 'react-bootstrap';
+import queryString from 'query-string';
+import HttpRequest from '../HttpRequest';
+import BroadcastDetail from './BroadcastDetail';
+import helpers from '../../helpers';
+
+const BroadcastDetailContainer = props => (
+  <Grid>
+    <HttpRequest
+      path={helpers.getBroadcastByIdPath(props.match.params.broadcastId)}
+      query={queryString.parse(window.location.search)}
+    >
+      {res => <BroadcastDetail broadcast={res.data} />}
+    </HttpRequest>
+  </Grid>
+);
+
+BroadcastDetailContainer.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({ broadcastId: PropTypes.string.isRequired }).isRequired,
+  }).isRequired,
+};
+
+export default BroadcastDetailContainer;

--- a/client/src/Components/BroadcastDetail/BroadcastStatsContainer.js
+++ b/client/src/Components/BroadcastDetail/BroadcastStatsContainer.js
@@ -1,26 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Grid } from 'react-bootstrap';
-import queryString from 'query-string';
 import HttpRequest from '../HttpRequest';
-import BroadcastDetail from './BroadcastDetail';
+import BroadcastStats from './BroadcastStats';
 import helpers from '../../helpers';
 
-const BroadcastDetailContainer = props => (
+const BroadcastStatsContainer = ({ broadcastId}) => (
   <Grid>
     <HttpRequest
-      path={helpers.getBroadcastByIdPath(props.match.params.broadcastId)}
-      query={queryString.parse(window.location.search)}
+      path={helpers.getBroadcastByIdPath(broadcastId)}
     >
-      {res => <BroadcastDetail broadcast={res.data} />}
+      {res => <BroadcastStats stats={res.data.stats} />}
     </HttpRequest>
   </Grid>
 );
 
-BroadcastDetailContainer.propTypes = {
-  match: PropTypes.shape({
-    params: PropTypes.shape({ broadcastId: PropTypes.string.isRequired }).isRequired,
-  }).isRequired,
+BroadcastStatsContainer.propTypes = {
+  broadcastId: PropTypes.string.isRequired,
 };
 
-export default BroadcastDetailContainer;
+export default BroadcastStatsContainer;

--- a/client/src/Components/TemplateList/TemplateList.js
+++ b/client/src/Components/TemplateList/TemplateList.js
@@ -4,7 +4,12 @@ import TemplateListItem from './TemplateListItem';
 
 const TemplateList = (props) => {
   const topicTemplates = props.templates.map((templateName) => (
-    <TemplateListItem key={templateName} name={templateName} text={props.topic[templateName]} />
+    <TemplateListItem
+      key={templateName}
+      name={templateName}
+      text={props.topic[templateName]}
+      topic={props.topic[`${templateName}Topic`]}
+    />
   ));
   return <div>{topicTemplates}</div>;
 };

--- a/client/src/Components/TemplateList/TemplateList.js
+++ b/client/src/Components/TemplateList/TemplateList.js
@@ -15,8 +15,12 @@ const TemplateList = (props) => {
 };
 
 TemplateList.propTypes = {
-  templates: PropTypes.array.isRequired,
+  templates: PropTypes.array,
   topic: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+};
+
+TemplateList.defaultProps = {
+  templates: []
 };
 
 export default TemplateList;

--- a/client/src/Components/TopicDetail/TopicDetail.js
+++ b/client/src/Components/TopicDetail/TopicDetail.js
@@ -1,81 +1,33 @@
 import React from 'react';
 import { Panel, PageHeader } from 'react-bootstrap';
 import PropTypes from 'prop-types';
-
-import TemplateList from '../TemplateList/TemplateList';
+import TopicTemplates from './TopicTemplates';
 import CampaignLink from '../CampaignLink';
 import ContentfulLink from '../ContentfulLink';
 
-const getTemplates = (topic) => {
-  const type = topic.__typename;
-
-  if (type === 'AutoReplyTopic' || type === 'AutoReplySignupTopic') {
-    return (
-      <TemplateList
-        topic={topic}
-        templates={['autoReply']} 
-      />
-    );
-  }
-
-  if (type === 'TextPostTopic') {
-    return (
-      <TemplateList
-        topic={topic}
-        templates={['invalidText', 'completedTextPost']} 
-      />
-    );
-  }
-
-  if (type === 'PhotoPostTopic') {
-    return (
-      <TemplateList
-        topic={topic}
-        templates={[
-          'startPhotoPostAutoReply',
-          'askQuantity',
-          'invalidQuantity',
-          'askPhoto',
-          'invalidPhoto',
-          'askCaption',
-          'invalidCaption',
-          'askWhyParticipated',
-          'invalidWhyParticipated',
-          'completedPhotoPost',
-          'completedPhotoPostAutoReply',
-        ]} 
-      />
-    );
-  }
-
-  return null;
-}
-
-const TopicDetail = (props) => {
-  const topic = props.topic;
-  const campaignTitle = topic.campaign ? <CampaignLink campaign={topic.campaign} linkDisabled={false} /> : '(None)';
-  return (
-    <div>
-      <PageHeader>{topic.name} <small><br />{topic.__typename}</small></PageHeader>
-      <Panel>
-        <Panel.Body>
-          <ContentfulLink entryId={topic.id} />
-          <p>
-            {campaignTitle}
-          </p>
-        </Panel.Body>
-      </Panel>
-      {getTemplates(topic)}
-    </div>
-  );
-};
+const TopicDetail = ({ topic }) => (
+  <div>
+    <PageHeader>{topic.name} <small><br />{topic.__typename}</small></PageHeader>
+    <Panel>
+      <Panel.Body>
+        <ContentfulLink entryId={topic.id} />
+        <p>
+          {topic.campaign
+            ? <CampaignLink campaign={topic.campaign} linkDisabled={false} />
+            : <span>(None)</span>}
+        </p>
+      </Panel.Body>
+    </Panel>
+    <TopicTemplates topic={topic} />
+  </div>
+);
 
 TopicDetail.propTypes = {
   topic: PropTypes.shape({
     id: PropTypes.string,
-    type: PropTypes.string,
-    postType: PropTypes.string,
-    templates: PropTypes.object,
+    __typename: PropTypes.string,
+    name: PropTypes.string,
+    campaign: PropTypes.object,
   }).isRequired,
 };
 

--- a/client/src/Components/TopicDetail/TopicTemplates.js
+++ b/client/src/Components/TopicDetail/TopicTemplates.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TemplateList from '../TemplateList/TemplateList';
+
+const TopicTemplates = ({ topic }) => {
+  const type = topic.__typename;
+
+  if (type === 'AskSubscriptionStatusBroadcastTopic') {
+    return (
+      <TemplateList
+        topic={topic}
+        templates={[
+          'saidActive',
+          'saidLess',
+          'saidNeedMoreInfo',
+          'invalidAskSubscriptionStatusResponse',
+        ]} 
+      />
+    );
+  }
+
+  if (type === 'AutoReplyTopic' || type === 'AutoReplySignupTopic') {
+    return (
+      <TemplateList
+        topic={topic}
+        templates={['autoReply']} 
+      />
+    );
+  }
+
+  if (type === 'TextPostTopic') {
+    return (
+      <TemplateList
+        topic={topic}
+        templates={['invalidText', 'completedTextPost']} 
+      />
+    );
+  }
+
+  if (type === 'PhotoPostTopic') {
+    return (
+      <TemplateList
+        topic={topic}
+        templates={[
+          'startPhotoPostAutoReply',
+          'askQuantity',
+          'invalidQuantity',
+          'askPhoto',
+          'invalidPhoto',
+          'askCaption',
+          'invalidCaption',
+          'askWhyParticipated',
+          'invalidWhyParticipated',
+          'completedPhotoPost',
+          'completedPhotoPostAutoReply',
+        ]} 
+      />
+    );
+  }
+
+  return null;
+}
+
+TopicTemplates.propTypes = {
+  topic: PropTypes.object.isRequired,
+};
+
+export default TopicTemplates;

--- a/client/src/Components/TopicDetail/TopicTemplates.js
+++ b/client/src/Components/TopicDetail/TopicTemplates.js
@@ -2,80 +2,51 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import TemplateList from '../TemplateList/TemplateList';
 
-const TopicTemplates = ({ topic }) => {
-  const type = topic.__typename;
-
-  if (type === 'AskSubscriptionStatusBroadcastTopic') {
-    return (
-      <TemplateList
-        topic={topic}
-        templates={[
-          'saidActive',
-          'saidLess',
-          'saidNeedMoreInfo',
-          'invalidAskSubscriptionStatusResponse',
-        ]} 
-      />
-    );
-  }
-
-  if (type === 'AskYesNoBroadcastTopic') {
-    return (
-      <TemplateList
-        topic={topic}
-        templates={[
-          'saidYes',
-          'saidNo',
-          'invalidAskYesNoResponse',
-        ]} 
-      />
-    );
-  }
-
-  if (type === 'AutoReplyTopic' || type === 'AutoReplySignupTopic') {
-    return (
-      <TemplateList
-        topic={topic}
-        templates={['autoReply']} 
-      />
-    );
-  }
-
-  if (type === 'TextPostTopic') {
-    return (
-      <TemplateList
-        topic={topic}
-        templates={['invalidText', 'completedTextPost']} 
-      />
-    );
-  }
-
-  if (type === 'PhotoPostTopic') {
-    return (
-      <TemplateList
-        topic={topic}
-        templates={[
-          'startPhotoPostAutoReply',
-          'askQuantity',
-          'invalidQuantity',
-          'askPhoto',
-          'invalidPhoto',
-          'askCaption',
-          'invalidCaption',
-          'askWhyParticipated',
-          'invalidWhyParticipated',
-          'completedPhotoPost',
-          'completedPhotoPostAutoReply',
-        ]} 
-      />
-    );
-  }
-
-  return null;
+const typeTemplateMap = {
+  AskSubscriptionStatusBroadcastTopic: [
+    'saidActive',
+    'saidLess',
+    'saidNeedMoreInfo',
+    'invalidAskSubscriptionStatusResponse',
+  ],
+  AskYesNoBroadcastTopic: [
+    'saidYes',
+    'saidNo',
+    'invalidAskYesNoResponse',
+  ],
+  AutoReplyTopic: [
+    'autoReply'
+  ],
+  AutoReplySignupTopic: [
+    'autoReply'
+  ],
+  PhotoPostTopic: [
+    'startPhotoPostAutoReply',
+    'askQuantity',
+    'invalidQuantity',
+    'askPhoto',
+    'invalidPhoto',
+    'askCaption',
+    'invalidCaption',
+    'askWhyParticipated',
+    'invalidWhyParticipated',
+    'completedPhotoPost',
+    'completedPhotoPostAutoReply',
+  ],
+  TextPostTopic: [
+    'invalidText',
+    'completedTextPost',
+  ],
 }
 
+const TopicTemplates = ({ topic }) => (
+  <TemplateList topic={topic} templates={typeTemplateMap[topic.__typename]}/>
+);
+
 TopicTemplates.propTypes = {
-  topic: PropTypes.object.isRequired,
+  topic: PropTypes.shape({
+    __typename: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 export default TopicTemplates;

--- a/client/src/Components/TopicDetail/TopicTemplates.js
+++ b/client/src/Components/TopicDetail/TopicTemplates.js
@@ -19,6 +19,19 @@ const TopicTemplates = ({ topic }) => {
     );
   }
 
+  if (type === 'AskYesNoBroadcastTopic') {
+    return (
+      <TemplateList
+        topic={topic}
+        templates={[
+          'saidYes',
+          'saidNo',
+          'invalidAskYesNoResponse',
+        ]} 
+      />
+    );
+  }
+
   if (type === 'AutoReplyTopic' || type === 'AutoReplySignupTopic') {
     return (
       <TemplateList

--- a/client/src/graphql.js
+++ b/client/src/graphql.js
@@ -95,6 +95,7 @@ export const getBroadcastByIdQuery = gql`
         url
       }
       ... on AskSubscriptionStatusBroadcastTopic {
+        invalidAskSubscriptionStatusResponse
         saidActive
         saidActiveTopic {
           id
@@ -106,7 +107,19 @@ export const getBroadcastByIdQuery = gql`
           name
         }
         saidNeedMoreInfo
-        invalidAskSubscriptionStatusResponse
+      }
+      ... on AskYesNoBroadcastTopic {
+        invalidAskYesNoResponse
+        saidNo
+        saidNoTopic {
+          id
+          name
+        }
+        saidYes
+        saidYesTopic {
+          id
+          name
+        }
       }
     }
   }

--- a/client/src/graphql.js
+++ b/client/src/graphql.js
@@ -8,6 +8,14 @@ const campaignFields = `
   }
 `;
 
+const topicFields = `
+  topic {
+    id
+    name
+    __typename
+  }
+`;
+
 const autoReplySignupCampaignFragment = gql`
   fragment autoReplySignupCampaign on AutoReplySignupTopic {
     ${campaignFields}
@@ -51,11 +59,7 @@ const webSignupConfirmations = `
   webSignupConfirmations {
     ${campaignFields}
     text
-    topic {
-      id
-      name
-      __typename
-    }
+    ${topicFields}
   }
 `;
 
@@ -120,6 +124,15 @@ export const getBroadcastByIdQuery = gql`
           id
           name
         }
+      }
+      ... on AutoReplyBroadcast {
+        ${topicFields}
+      }
+      ... on PhotoPostBroadcast {
+        ${topicFields}
+      }
+      ... on TextPostBroadcast {
+        ${topicFields}
       }
     }
   }

--- a/client/src/graphql.js
+++ b/client/src/graphql.js
@@ -82,7 +82,35 @@ export const getCampaignDetailByIdQuery = gql`
   ${autoReplySignupCampaignFragment}
   ${photoPostCampaignFragment}
   ${textPostCampaignFragment}  
-`
+`;
+
+export const getBroadcastByIdQuery = gql`
+  query getBroadcastById($id: String!) {
+    broadcast(id: $id) {
+      id
+      name
+      text
+      contentType
+      attachments {
+        url
+      }
+      ... on AskSubscriptionStatusBroadcastTopic {
+        saidActive
+        saidActiveTopic {
+          id
+          name
+        }
+        saidLess
+        saidLessTopic {
+          id
+          name
+        }
+        saidNeedMoreInfo
+        invalidAskSubscriptionStatusResponse
+      }
+    }
+  }
+`;
 
 export const getTopicByIdQuery = gql`
   query getTopicById($id: String!) {


### PR DESCRIPTION
Front end changes for https://github.com/DoSomething/gambit/pull/471, with a bit of cleanup:

* Fetches a broadcast and its topic templates from GraphQL, instead of the Gambit `GET /broadcasts/:id` endpoint. Once this is in place, we'll refactor the Gambit `GET /broadcasts/:id` endpoint to only return broadcast stats (it's currently returning a similar GraphQL request for a `broadcast(id) -- but without the necessary topic templates to get the full view of all associated data)

* Splits the `BroadcastDetail` component out into `BroadcastStats` components