### PR TITLE
Updates graphql query schemas (getBroadcastById)

### DIFF
--- a/client/src/Components/TemplateList/TemplateList.js
+++ b/client/src/Components/TemplateList/TemplateList.js
@@ -4,7 +4,8 @@ import lodash from 'lodash';
 import TemplateListItem from './TemplateListItem';
 
 const TemplateList = (props) => {
-  console.log(props.topic)
+  // TODO: Move template logic to helper so the TemplateList doesn't
+  // have to know anything about how to access the correct values
   const topicTemplates = props.templates.map((templateName) => (
     <TemplateListItem
       key={templateName[0]}

--- a/client/src/Components/TemplateList/TemplateList.js
+++ b/client/src/Components/TemplateList/TemplateList.js
@@ -1,14 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import lodash from 'lodash';
 import TemplateListItem from './TemplateListItem';
 
 const TemplateList = (props) => {
+  console.log(props.topic)
   const topicTemplates = props.templates.map((templateName) => (
     <TemplateListItem
-      key={templateName}
-      name={templateName}
-      text={props.topic[templateName]}
-      topic={props.topic[`${templateName}Topic`]}
+      key={templateName[0]}
+      name={templateName[0]}
+      text={lodash.get(props.topic, templateName[1] || templateName[0]) || 'N/A'}
+      topic={lodash.get(props.topic, templateName[2])}
     />
   ));
   return <div>{topicTemplates}</div>;

--- a/client/src/Components/TopicDetail/TopicTemplates.js
+++ b/client/src/Components/TopicDetail/TopicTemplates.js
@@ -1,52 +1,70 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import TemplateList from '../TemplateList/TemplateList';
-
+/**
+ * 1st pass, pretty verbose, but takes the "mapping" pretty literal :)
+ * 
+ * Order is important when defining these maps
+ * index 0 holds the title (or flat property that holds the text)
+ * index 1 holds the path to the transition's text property
+ * index 2 holds the path to the transition's topic property
+ */
 const typeTemplateMap = {
   AskMultipleChoiceBroadcastTopic: [
-    'saidFirstChoice',
-    'saidSecondChoice',
-    'saidThirdChoice',
-    'invalidAskMultipleChoiceResponse',
+    ['saidFirstChoice', 'saidFirstChoiceTransition.text', 'saidFirstChoiceTransition.topic'],
+    ['saidSecondChoice', 'saidSecondChoiceTransition.text', 'saidSecondChoiceTransition.topic'],
+    ['saidThirdChoice', 'saidThirdChoiceTransition.text', 'saidThirdChoiceTransition.topic'],
+    ['saidFourthChoice', 'saidFourthChoiceTransition.text', 'saidFourthChoiceTransition.topic'],
+    ['saidFifthChoice', 'saidFifthChoiceTransition.text', 'saidFifthChoiceTransition.topic'],
+    /**
+     * Since the text value is held in this property name we don't need
+     * to specify a path to get it. This way the value at index 0 is both
+     * the title of the list item and the name of the property holding the
+     * text.
+     */
+    ['invalidAskMultipleChoiceResponse'],
   ],
   AskSubscriptionStatusBroadcastTopic: [
-    'saidActive',
-    'saidLess',
-    'saidNeedMoreInfo',
-    'invalidAskSubscriptionStatusResponse',
+    ['saidActive', 'saidActiveTransition.text', 'saidActiveTransition.text'],
+    ['saidLess', 'saidLessTransition.text', 'saidLessTransition.text'],
+    ['saidNeedMoreInfo'],
+    ['invalidAskSubscriptionStatusResponse'],
   ],
   AskVotingPlanStatusBroadcastTopic: [
-    'saidNotVoting',
-    'saidVoted',
-    'saidCantVote',
+    ['saidNotVoting', 'saidNotVotingTransition.text', 'saidNotVotingTransition.topic'],
+    ['saidVoted', 'saidVotedTransition.text', 'saidVotedTransition.topic'],
+    ['saidCantVote', 'saidCantVoteTransition.text', 'saidCantVoteTransition.topic'],
   ],
   AskYesNoBroadcastTopic: [
-    'saidYes',
-    'saidNo',
-    'invalidAskYesNoResponse',
+    ['saidYes', 'saidYesTransition.text', 'saidYesTransition.topic'],
+    ['saidNo', 'saidNoTransition.text', 'saidNoTransition.topic'],
+    ['invalidAskYesNoResponse'],
+  ],
+  AutoReplyBroadcast: [
+    ['autoReply', 'topic.autoReply']
   ],
   AutoReplyTopic: [
-    'autoReply'
+    ['autoReply']
   ],
   AutoReplySignupTopic: [
-    'autoReply'
+    ['autoReply']
   ],
   PhotoPostTopic: [
-    'startPhotoPostAutoReply',
-    'askQuantity',
-    'invalidQuantity',
-    'askPhoto',
-    'invalidPhoto',
-    'askCaption',
-    'invalidCaption',
-    'askWhyParticipated',
-    'invalidWhyParticipated',
-    'completedPhotoPost',
-    'completedPhotoPostAutoReply',
+    ['startPhotoPostAutoReply'],
+    ['askQuantity'],
+    ['invalidQuantity'],
+    ['askPhoto'],
+    ['invalidPhoto'],
+    ['askCaption'],
+    ['invalidCaption'],
+    ['askWhyParticipated'],
+    ['invalidWhyParticipated'],
+    ['completedPhotoPost'],
+    ['completedPhotoPostAutoReply'],
   ],
   TextPostTopic: [
-    'invalidText',
-    'completedTextPost',
+    ['invalidText'],
+    ['completedTextPost'],
   ],
 }
 

--- a/client/src/graphql.js
+++ b/client/src/graphql.js
@@ -19,6 +19,18 @@ const topicFields = `
     id
     name
     __typename
+    ${contentfulCampaignFields}
+    ${rogueCampaignFields}
+  }
+`;
+
+const transitionTopicFields = `
+  topic {
+    id
+    name
+    __typename
+    ${contentfulCampaignFields}
+    ${rogueCampaignFields}
   }
 `;
 
@@ -36,51 +48,15 @@ const campaignTransitionFields = `
 const campaignTopicTransitionFragments = `
   fragment autoReplyCampaignTransition on AutoReplyTransition {
     ${campaignTransitionFields}
-    topic {
-      id
-      name
-      contentType
-      ...autoReplyCampaign
-    }
+    ${transitionTopicFields}
   }
   fragment photoPostCampaignTransition on PhotoPostTransition {
     ${campaignTransitionFields}
-    topic {
-      id
-      name
-      contentType
-      ...photoPostCampaign
-    }
+    ${transitionTopicFields}
   }
   fragment textPostCampaignTransition on TextPostTransition {
     ${campaignTransitionFields}
-    topic {
-      id
-      name
-      contentType
-      ...textPostCampaign
-    }
-  }
-`;
-
-const autoReplyCampaignFragment = gql`
-  fragment autoReplyCampaign on AutoReplyTopic {
-    ${contentfulCampaignFields}
-    ${rogueCampaignFields}
-  }
-`;
-
-const photoPostCampaignFragment = gql`
-  fragment photoPostCampaign on PhotoPostTopic {
-    ${contentfulCampaignFields}
-    ${rogueCampaignFields}
-  }
-`;
-
-const textPostCampaignFragment = gql`
-  fragment textPostCampaign on TextPostTopic {
-    ${contentfulCampaignFields}
-    ${rogueCampaignFields}
+    ${transitionTopicFields}
   }
 `;
 
@@ -118,9 +94,6 @@ export const getCampaignDashboardQuery = gql`
     ${conversationTriggers}
     ${webSignupConfirmations}
   }
-  ${autoReplyCampaignFragment}
-  ${photoPostCampaignFragment}
-  ${textPostCampaignFragment}
   ${campaignTopicTransitionFragments}
 `;
 
@@ -134,9 +107,6 @@ export const getCampaignDetailByIdQuery = gql`
     ${conversationTriggers}
     ${webSignupConfirmations}
   }
-  ${autoReplyCampaignFragment}
-  ${photoPostCampaignFragment}
-  ${textPostCampaignFragment}
   ${campaignTopicTransitionFragments}
 `;
 
@@ -199,7 +169,14 @@ export const getBroadcastByIdQuery = gql`
         }
       }
       ... on AutoReplyBroadcast {
-        ${topicFields}
+        topic {
+          id
+          name
+          autoReply
+          __typename
+          ${contentfulCampaignFields}
+          ${rogueCampaignFields}
+        }
       }
       ... on PhotoPostBroadcast {
         ${topicFields}
@@ -209,9 +186,6 @@ export const getBroadcastByIdQuery = gql`
       }
     }
   }
-  ${autoReplyCampaignFragment}
-  ${photoPostCampaignFragment}
-  ${textPostCampaignFragment}
   ${campaignTopicTransitionFragments}
 `;
 
@@ -263,9 +237,6 @@ export const getTopicByIdQuery = gql`
       }
     }
   }
-  ${autoReplyCampaignFragment}
-  ${photoPostCampaignFragment}
-  ${textPostCampaignFragment}
 `;
 
 export const postFieldsFragment = gql`

--- a/client/src/graphql.js
+++ b/client/src/graphql.js
@@ -152,64 +152,50 @@ export const getBroadcastByIdQuery = gql`
       }
       ... on AskMultipleChoiceBroadcastTopic {
         invalidAskMultipleChoiceResponse
-        saidFirstChoice
-        saidFirstChoiceTopic {
-          id
-          name
+        saidFirstChoiceTransition {
+          ${campaignTransitionTypes}
         }
-        saidSecondChoice
-        saidSecondChoiceTopic {
-          id
-          name
+        saidSecondChoiceTransition {
+          ${campaignTransitionTypes}
         }
-        saidThirdChoice
-        saidThirdChoiceTopic {
-          id
-          name
+        saidThirdChoiceTransition {
+          ${campaignTransitionTypes}
+        }
+        saidFourthChoiceTransition {
+          ${campaignTransitionTypes}
+        }
+        saidFifthChoiceTransition {
+          ${campaignTransitionTypes}
         }
       }
       ... on AskSubscriptionStatusBroadcastTopic {
         invalidAskSubscriptionStatusResponse
-        saidActive
-        saidActiveTopic {
-          id
-          name
+        saidActiveTransition {
+          ...autoReplyCampaignTransition
         }
-        saidLess
-        saidLessTopic {
-          id
-          name
+        saidLessTransition {
+          ...autoReplyCampaignTransition
         }
         saidNeedMoreInfo
       }
       ... on AskVotingPlanStatusBroadcastTopic {
-        saidNotVoting
-        saidNotVotingTopic {
-          id
-          name
+        saidNotVotingTransition {
+          ${campaignTransitionTypes}
         }
-        saidVoted
-        saidVotedTopic {
-          id
-          name
+        saidVotedTransition {
+          ${campaignTransitionTypes}
         }
-        saidCantVote
-        saidCantVoteTopic {
-          id
-          name
+        saidCantVoteTransition {
+          ${campaignTransitionTypes}
         }
       }
       ... on AskYesNoBroadcastTopic {
         invalidAskYesNoResponse
-        saidNo
-        saidNoTopic {
-          id
-          name
+        saidYesTransition {
+          ${campaignTransitionTypes}
         }
-        saidYes
-        saidYesTopic {
-          id
-          name
+        saidNoTransition {
+          ${campaignTransitionTypes}
         }
       }
       ... on AutoReplyBroadcast {
@@ -223,6 +209,10 @@ export const getBroadcastByIdQuery = gql`
       }
     }
   }
+  ${autoReplyCampaignFragment}
+  ${photoPostCampaignFragment}
+  ${textPostCampaignFragment}
+  ${campaignTopicTransitionFragments}
 `;
 
 export const getTopicByIdQuery = gql`


### PR DESCRIPTION
## What does this PR do?
- It updates the `getBroadcastById` GraphQL query schema
- It updates the `TopicTemplates` and `TemplateList` components to use the new topic schema

## How should it be tested
- Make sure broadcast detail links are functional and render correctly. [Example](http://localhost:3001/broadcasts/5W9tjhwhDEbQekbpJTy0Ud)(AskYesNo)
  - A `TemplateListItem` component that get a topic should render a link to the topic. Example seen in the link above.

## To Do before being ready for final review
- [x] Fix `500` error when viewing details for `photoPostBroadcasts` and `textPostBroadcast` types. - Fixed in https://github.com/DoSomething/gambit/pull/506