### PR TITLE
[pr] Avoid polling requests in HttpRequest component

### DIFF
--- a/client/src/Components/HttpRequest.js
+++ b/client/src/Components/HttpRequest.js
@@ -53,7 +53,7 @@ const HttpRequest = function (props) {
     return function cleanup() {
       return true;
     };
-  }, [isLoading]);
+  }, []);
 
   if (isLoading) {
     return <ProgressBar active now={100} />;

--- a/client/src/Components/HttpRequest.js
+++ b/client/src/Components/HttpRequest.js
@@ -41,13 +41,19 @@ const HttpRequest = function (props) {
 
   useEffect(() => {
     axios.get(helpers.apiUrl(props.path), { params })
-      .then(res => setHttpResponse(res))
-      .catch(error => setHttpError(error));
+      .then((res) => {
+        setHttpResponse(res);
+        setIsLoading(false);
+       })
+      .catch((error) => {
+        setHttpError(error);
+        setIsLoading(false);
+      });
 
     return function cleanup() {
-      setIsLoading(false);
+      return true;
     };
-  });
+  }, [isLoading]);
 
   if (isLoading) {
     return <ProgressBar active now={100} />;


### PR DESCRIPTION
#107 was making API requests continuously (hence #32), and unexpectedly.  I didn't catch this when I was working on local and staging, but for sure saw this in action on production when we sent out a broadcast. This PR passes an empty array as a second argument to the Effect Hook to avoid continuously making http requests after the component renders.

#107 also introduced a number of warning in the browser console. I may clean those up when there's time but for now, it seems wise to merge this and avoid regular polling.