### PR TITLE
Fixes pagination for broadcasts

### DIFF
--- a/client/src/Components/HttpRequest.js
+++ b/client/src/Components/HttpRequest.js
@@ -33,10 +33,12 @@ const HttpRequest = function (props) {
 
   const params = props.query;
   params.limit = pageSize;
+
   const clientQuery = queryString.parse(window.location.search);
   const skipCount = Number(clientQuery.skip) || 0;
+
   if (skipCount) {
-    params.skip = this.skipCount;
+    params.skip = skipCount;
   }
 
   useEffect(() => {


### PR DESCRIPTION
Fixes bug introduced in #107. The second page of Gambit API results (e.g. https://gambit-admin-staging.herokuapp.com/broadcasts?skip=50&) would throw an TypeError: `Cannot read property 'skipCount' of undefined`.

I'll deploy this branch to our staging Gambit Admin to confirm fix.
 