### PR TITLE
Adds link to Contentful ID on Triggers view

### DIFF
--- a/src/Components/AdminDashboard/AdminDashboard.js
+++ b/src/Components/AdminDashboard/AdminDashboard.js
@@ -14,15 +14,25 @@ const AdminDashboard = () => (
     >
       {(res) => {
         const rows = lodash.orderBy(res.data.topics.random, 'trigger')
-          .map((trigger) => {
-            const desc = trigger.reply.length ? trigger.reply : `@ ${trigger.redirect}`;
-            return (
+          .map((trigger) => (
               <Row componentClass="tr" key={trigger.trigger}>
-                <Col componentClass="td"><strong>{trigger.trigger}</strong></Col>
-                <Col componentClass="td">{desc}</Col>
+                <Col componentClass="td">
+                  {trigger.contentfulId ? (
+                    <a href={helpers.getContentfulUrlForEntryId(trigger.contentfulId)}>
+                      {trigger.trigger}
+                    </a>
+                    ) : (
+                    <>
+                      {trigger.trigger}
+                    </>
+                   )}
+                </Col>
+                <Col componentClass="td">
+                  {!trigger.redirect ? trigger.reply : `@ ${trigger.redirect}`}
+                </Col>
               </Row>
-            );
-          });
+            )
+          );
 
         return (
           <div>


### PR DESCRIPTION
This PR adds a link to a default topic trigger's Contentful ID if it exists, per https://github.com/DoSomething/gambit/pull/539

This `/triggers` view only displays triggers and their replies within the `random` topic. It could potentially useful for admins to see the triggers and replies in the hardcoded `unsubscribed`, `dss_`, or for users, or [voting plan](https://github.com/DoSomething/gambit/tree/main/brain/topics/votingPlan) RiveScript topics per Anthony's comment in https://www.pivotaltracker.com/n/projects/2401401/stories/174231934 (not being able to see all hardcoded triggers).

Here are ideas for displaying any other hardcoded triggers beyond the `random` topic ones:

* In a new section to bottom of the page in the `/triggers` view - seems easiest
* Add a check to`/topics/:id` to see whether the topic ID is a hardcoded one, and display its Rivescript triggers if so. Modify the list of default triggers to link to the topic permalink from the `{topic:[new topic]}` tag if the reply changes topic

The [hardcoded Ride and Seek topics](https://github.com/DoSomething/gambit/blob/6ba2a90acad0afdacfff38bd71076700676f915a/brain/topics/seatbelt.rive) would potentially also be handy to view, but this code should likely just be deprecated (asked about in it [Slack](https://dosomething.slack.com/archives/C03T8SDMS/p1604615901003000))