### PR TITLE
Update Customer.io payload to support null states.

### DIFF
--- a/src/Components/BroadcastDetail/BroadcastStatsContainer.js
+++ b/src/Components/BroadcastDetail/BroadcastStatsContainer.js
@@ -14,7 +14,7 @@ const BroadcastStatsContainer = ({ broadcastId}) => (
       {res => (
         <div>
           <BroadcastStats stats={res.data.stats} />
-          <BroadcastWebhook config={res.data.webhook} />
+          <BroadcastWebhook broadcastId={broadcastId} url={res.data.webhook.url} />
         </div>
       )}
     </HttpRequest>

--- a/src/Components/BroadcastDetail/BroadcastWebhook.js
+++ b/src/Components/BroadcastDetail/BroadcastWebhook.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Panel } from 'react-bootstrap';
 
-const BroadcastWebhook = props => (
+const BroadcastWebhook = ({ broadcastId, url }) => (
   <Panel>
     <Panel.Heading>
       <Panel.Title toggle>Settings</Panel.Title>
@@ -10,10 +10,16 @@ const BroadcastWebhook = props => (
     <Panel.Collapse>
       <Panel.Body>
         <p>
-          <code>{props.config.url}</code>
+          <code>{url}</code>
         </p>
         <pre>
-          <code>{JSON.stringify(props.config.body, null, 2)}</code>
+          <code>{`{
+  "broadcastId": "${broadcastId}",
+  "userId": "{{customer.id}}",
+  "addrState": {% if customer.addr_state != blank %}"{{customer.addr_state}}"{% else %}null{% endif %},
+  "mobile": "{{customer.phone}}",
+  "smsStatus": "{{customer.sms_status}}"
+}`}</code>
         </pre>
       </Panel.Body>
     </Panel.Collapse>
@@ -21,7 +27,8 @@ const BroadcastWebhook = props => (
 );
 
 BroadcastWebhook.propTypes = {
-  config: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  url: PropTypes.string.isRequired,
+  broadcastId: PropTypes.string.isRequired,
 };
 
 export default BroadcastWebhook;


### PR DESCRIPTION
This fixes an issue where Customer.io would get mad when `customer.addr_state` was null. We had to swap this into Gambit Admin as a string template because this uses Liquid tags that wouldn't work well in the JSON payload we used to retrieve from Gambit's `v2/broadcasts` endpoint.